### PR TITLE
Convert latestWeight to a reactive signal

### DIFF
--- a/src/legacy/utils/weightUtils.ts
+++ b/src/legacy/utils/weightUtils.ts
@@ -1,12 +1,23 @@
 import { type Weight } from '~/modules/weight/domain/weight'
 import { inForceGeneric } from '~/legacy/utils/generic/inForce'
+import { createMemo } from 'solid-js'
+import { userWeights } from '~/modules/weight/application/weight'
 
-export function latestWeight(weights: readonly Weight[]) {
+export function getLatestWeight(weights: readonly Weight[]) {
   if (weights.length === 0) {
     return null
   }
   return weights[weights.length - 1]
 }
+
+// Reactive signal that returns the latest weight from userWeights
+export const latestWeight = createMemo(() => {
+  const weights = userWeights()
+  if (weights.length === 0) {
+    return null
+  }
+  return weights[weights.length - 1]
+})
 
 export function firstWeight(weights: readonly Weight[]) {
   if (weights.length === 0) {
@@ -21,7 +32,7 @@ export function calculateWeightChange(weights: readonly Weight[]) {
     return null
   }
 
-  const latest = latestWeight(weights)
+  const latest = getLatestWeight(weights)
   if (latest === null) {
     return null
   }

--- a/src/sections/profile/components/MacroProfile.tsx
+++ b/src/sections/profile/components/MacroProfile.tsx
@@ -2,7 +2,6 @@ import { Show } from 'solid-js'
 import { latestWeight } from '~/legacy/utils/weightUtils'
 import { userMacroProfiles } from '~/modules/diet/macro-profile/application/macroProfile'
 import { CARD_BACKGROUND_COLOR, CARD_STYLE } from '~/modules/theme/constants'
-import { userWeights } from '~/modules/weight/application/weight'
 import { MacroTarget } from '~/sections/macro-nutrients/components/MacroTargets'
 
 // TODO: Rename MacroProfileComp to MacroProfile
@@ -10,8 +9,7 @@ export function MacroProfileComp() {
   return (
     <div class={`${CARD_BACKGROUND_COLOR} ${CARD_STYLE}`}>
       <Show
-        // TODO: latestWeight should be a signal
-        when={latestWeight(userWeights())}
+        when={latestWeight()}
         fallback={
           <h1>Não há pesos registrados, o perfil não pode ser calculado</h1>
         }

--- a/src/sections/weight/components/WeightEvolution.tsx
+++ b/src/sections/weight/components/WeightEvolution.tsx
@@ -9,7 +9,7 @@ import { CapsuleContent } from '~/sections/common/components/capsule/CapsuleCont
 import {
   calculateWeightProgress,
   firstWeight,
-  latestWeight,
+  getLatestWeight,
 } from '~/legacy/utils/weightUtils'
 import { currentUser, currentUserId } from '~/modules/user/application/user'
 import {
@@ -271,7 +271,7 @@ function WeightChart(props: {
         const open = firstWeight(weights)?.weight ?? 0
         const low = Math.min(...weights.map((weight) => weight.weight))
         const high = Math.max(...weights.map((weight) => weight.weight))
-        const close = latestWeight(weights)?.weight ?? 0
+        const close = getLatestWeight(weights)?.weight ?? 0
 
         return {
           date: day,


### PR DESCRIPTION
Transform latestWeight into a reactive signal using createMemo to enhance UI reactivity when user weights change. Rename the function to getLatestWeight for clarity in array processing. Update MacroProfile and WeightEvolution components to utilize the new signal and function accordingly. Remove the TODO comment regarding latestWeight being a signal.

Fixes #519