### PR TITLE
refactor: move createNewMacroProfile to macroProfile module

### DIFF
--- a/src/modules/diet/macro-profile/domain/macroProfile.ts
+++ b/src/modules/diet/macro-profile/domain/macroProfile.ts
@@ -13,3 +13,22 @@ export const macroProfileSchema = z.object({
 })
 
 export type MacroProfile = Readonly<z.infer<typeof macroProfileSchema>>
+
+/**
+ * Creates a new MacroProfile with default values.
+ * Used for initializing new macro profiles before saving to database.
+ *
+ * @param owner - User ID who owns this macro profile
+ * @param targetDay - Date for which this profile applies
+ * @returns A new MacroProfile with default values for all macro nutrients
+ */
+export function createMacroProfile(owner: number, targetDay: Date): MacroProfile {
+  return {
+    id: -1,
+    owner,
+    target_day: targetDay,
+    gramsPerKgCarbs: 0,
+    gramsPerKgProtein: 0,
+    gramsPerKgFat: 0,
+  }
+}

--- a/src/sections/macro-nutrients/components/MacroTargets.tsx
+++ b/src/sections/macro-nutrients/components/MacroTargets.tsx
@@ -1,5 +1,8 @@
 import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
-import { type MacroProfile } from '~/modules/diet/macro-profile/domain/macroProfile'
+import { 
+  type MacroProfile,
+  createMacroProfile
+} from '~/modules/diet/macro-profile/domain/macroProfile'
 import {
   dateToYYYYMMDD,
   getTodayYYYMMDD,
@@ -308,18 +311,8 @@ function MacroTargetSetting(props: {
   const grams = () => emptyIfZeroElse2Decimals(props.target.grams)
   const gramsPerKg = () => emptyIfZeroElse2Decimals(props.target.gramsPerKg)
 
-  // TODO: Move to macroProfile module
-  const createNewMacroProfile = () => ({
-    id: -1,
-    owner: currentUserId(),
-    target_day: stringToDate(targetDay()),
-    gramsPerKgCarbs: 0,
-    gramsPerKgProtein: 0,
-    gramsPerKgFat: 0,
-  })
-
   const onSetGramsPerKg = (gramsPerKg: number) => {
-    const profile_ = props.currentProfile ?? createNewMacroProfile()
+    const profile_ = props.currentProfile ?? createMacroProfile(currentUserId(), stringToDate(targetDay()))
     onSaveMacroProfile({
       ...profile_,
       [`gramsPerKg${props.field.charAt(0).toUpperCase() + props.field.slice(1)}`]:
@@ -328,7 +321,7 @@ function MacroTargetSetting(props: {
   }
 
   const onSetGrams = (grams: number) => {
-    const profile_ = props.currentProfile ?? createNewMacroProfile()
+    const profile_ = props.currentProfile ?? createMacroProfile(currentUserId(), stringToDate(targetDay()))
     onSaveMacroProfile({
       ...profile_,
       [`gramsPerKg${props.field.charAt(0).toUpperCase() + props.field.slice(1)}`]:


### PR DESCRIPTION
Resolves #550

Moves the createNewMacroProfile function from MacroTargets component to the
macroProfile domain module, improving code organization and reusability.

Changes:
- Added createMacroProfile function to macroProfile domain module
- Updated MacroTargets.tsx to import and use the new function
- Removed local createNewMacroProfile implementation
- Added proper JSDoc documentation for the new function

This change follows domain-driven design principles by placing the macro profile
creation logic in the appropriate domain module rather than in UI components.