### PR TITLE
feat: implement ItemGroup factory functions and replace manual object creation

### DIFF
--- a/src/legacy/utils/data/itemGroupEditor.test.ts
+++ b/src/legacy/utils/data/itemGroupEditor.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { ItemGroupEditor } from '~/legacy/utils/data/itemGroupEditor'
 import { type Item } from '~/modules/diet/item/domain/item'
 
-import { type ItemGroup } from '~/modules/diet/item-group/domain/itemGroup'
+import { type ItemGroup, createSimpleItemGroup } from '~/modules/diet/item-group/domain/itemGroup'
 
 function mockItem(): Item {
   return {
@@ -20,13 +20,13 @@ function mockItem(): Item {
 }
 
 function mockGroup(): ItemGroup {
-  return {
+  const group = createSimpleItemGroup({
     name: 'test:name',
     items: [],
-    type: 'simple',
-    id: 1000,
     quantity: 0,
-  }
+  })
+  // Override the generated ID for testing
+  return { ...group, id: 1000 }
 }
 
 describe('ItemGroupEditor', () => {

--- a/src/legacy/utils/data/itemGroupEditor.ts
+++ b/src/legacy/utils/data/itemGroupEditor.ts
@@ -20,11 +20,11 @@ export class ItemGroupEditor
 
   setRecipe(recipe: Recipe['id'] | undefined) {
     if (recipe === undefined) {
-      this.group.type = 'simple'
+      this.group.groupType = 'simple'
       this.group.recipe = undefined
       return this
     }
-    this.group.type = 'recipe'
+    this.group.groupType = 'recipe'
     this.group.recipe = recipe
     return this
   }

--- a/src/legacy/utils/groupUtils.ts
+++ b/src/legacy/utils/groupUtils.ts
@@ -1,6 +1,8 @@
 import {
   type ItemGroup,
   type RecipedItemGroup,
+  createSimpleItemGroup,
+  createRecipedItemGroup,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { type Item } from '~/modules/diet/item/domain/item'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
@@ -64,14 +66,11 @@ export function convertToGroups(convertible: GroupConvertible): ItemGroup[] {
 
   if ('__type' in convertible && convertible.__type === 'Recipe') {
     return [
-      {
-        id: generateId(),
+      createRecipedItemGroup({
         name: convertible.name,
         items: [...convertible.items],
-        quantity: calculateGroupQuantity(convertible.items),
-        type: 'recipe',
         recipe: convertible.id,
-      },
+      }),
     ]
   }
 
@@ -81,14 +80,11 @@ export function convertToGroups(convertible: GroupConvertible): ItemGroup[] {
 
   if ('reference' in convertible) {
     return [
-      // TODO: createItemGroup({ items: [container] })
-      {
-        id: generateId(),
+      createSimpleItemGroup({
         name: convertible.name,
         items: [{ ...convertible } satisfies Item],
         quantity: convertible.quantity,
-        type: 'simple',
-      } satisfies ItemGroup,
+      }),
     ]
   }
 

--- a/src/legacy/utils/groupUtils.ts
+++ b/src/legacy/utils/groupUtils.ts
@@ -69,6 +69,7 @@ export function convertToGroups(convertible: GroupConvertible): ItemGroup[] {
       createRecipedItemGroup({
         name: convertible.name,
         items: [...convertible.items],
+        quantity: calculateGroupQuantity(convertible.items),
         recipe: convertible.id,
       }),
     ]

--- a/src/modules/diet/item-group/domain/itemGroup.ts
+++ b/src/modules/diet/item-group/domain/itemGroup.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { itemSchema } from '~/modules/diet/item/domain/item'
+import { generateId } from '~/legacy/utils/idUtils'
 
 // TODO: Add support for nested groups and recipes (recursive schema: https://github.com/colinhacks/zod#recursive-types)
 // TODO: In the future, it seems like discriminated unions will deprecated (https://github.com/colinhacks/zod/issues/2106)
@@ -9,12 +10,13 @@ export const simpleItemGroupSchema = z.object({
   name: z.string(),
   items: itemSchema.array(), // TODO: Support nested groups and recipes
   quantity: z.number(), // TODO: Replace quantity field with a getter that calculates it
-  type: z.literal('simple'),
+  groupType: z.literal('simple'),
   recipe: z
     .number()
     .nullable()
     .optional()
     .transform((recipe) => recipe ?? undefined),
+  __type: z.literal('ItemGroup'),
 })
 
 export const recipedItemGroupSchema = z.object({
@@ -22,11 +24,12 @@ export const recipedItemGroupSchema = z.object({
   name: z.string(),
   items: itemSchema.array().readonly(), // TODO: Support nested groups and recipes
   quantity: z.number(), // TODO: Replace quantity field with a getter that calculates it
-  type: z.literal('recipe'),
+  groupType: z.literal('recipe'),
   recipe: z.number(),
+  __type: z.literal('ItemGroup'),
 })
 
-export const itemGroupSchema = z.discriminatedUnion('type', [
+export const itemGroupSchema = z.discriminatedUnion('groupType', [
   simpleItemGroupSchema,
   recipedItemGroupSchema,
 ])
@@ -40,5 +43,66 @@ export type ItemGroup = Readonly<z.infer<typeof itemGroupSchema>>
 export function isSimpleSingleGroup(
   group: ItemGroup,
 ): group is SimpleItemGroup {
-  return group.type === 'simple' && group.items.length === 1
+  return group.groupType === 'simple' && group.items.length === 1
+}
+
+/**
+ * Creates a new simple ItemGroup with default values.
+ * Used for initializing new item groups that are not associated with a recipe.
+ *
+ * @param name - Name of the item group
+ * @param items - Array of items in the group
+ * @param quantity - Quantity of the group (default: 1)
+ * @returns A new SimpleItemGroup
+ */
+export function createSimpleItemGroup({
+  name,
+  items = [],
+  quantity = 1,
+}: {
+  name: string
+  items?: SimpleItemGroup['items']
+  quantity?: number
+}): SimpleItemGroup {
+  return {
+    id: generateId(),
+    name,
+    items,
+    quantity,
+    groupType: 'simple',
+    recipe: undefined,
+    __type: 'ItemGroup',
+  }
+}
+
+/**
+ * Creates a new recipe ItemGroup with default values.
+ * Used for initializing new item groups that are associated with a recipe.
+ *
+ * @param name - Name of the item group
+ * @param recipe - Recipe ID this group is associated with
+ * @param items - Array of items in the group
+ * @param quantity - Quantity of the group (default: 1)
+ * @returns A new RecipedItemGroup
+ */
+export function createRecipedItemGroup({
+  name,
+  recipe,
+  items = [],
+  quantity = 1,
+}: {
+  name: string
+  recipe: number
+  items?: RecipedItemGroup['items']
+  quantity?: number
+}): RecipedItemGroup {
+  return {
+    id: generateId(),
+    name,
+    items,
+    quantity,
+    groupType: 'recipe',
+    recipe,
+    __type: 'ItemGroup',
+  }
 }

--- a/src/modules/diet/meal/domain/meal.ts
+++ b/src/modules/diet/meal/domain/meal.ts
@@ -16,7 +16,6 @@ export const mealSchema = z.object({
 
 export type Meal = Readonly<z.infer<typeof mealSchema>>
 
-// TODO: Create factory function for other models
 export function createMeal({
   name,
   groups,

--- a/src/modules/diet/recipe/domain/recipe.ts
+++ b/src/modules/diet/recipe/domain/recipe.ts
@@ -22,9 +22,15 @@ export const recipeSchema = z.object({
 
 export type Recipe = Readonly<z.infer<typeof recipeSchema>>
 
-// TODO: Create/Move factory function for other models
 /**
- * @deprecated should be in another file
+ * Creates a new Recipe with calculated macros.
+ * Used for initializing new recipes before saving to database.
+ *
+ * @param name - Name of the recipe
+ * @param items - Array of items in the recipe
+ * @param preparedMultiplier - Multiplier for prepared quantity (default: 1)
+ * @param owner - User ID who owns this recipe
+ * @returns A new Recipe with calculated macros
  */
 export function createRecipe({
   name,
@@ -49,10 +55,18 @@ export function createRecipe({
   }
 }
 
-export function createRecipeFromGroup(group: ItemGroup) {
+/**
+ * Creates a Recipe from an ItemGroup.
+ * Useful for converting item groups into standalone recipes.
+ *
+ * @param group - ItemGroup to convert to a recipe
+ * @param owner - User ID who will own this recipe
+ * @returns A new Recipe created from the group
+ */
+export function createRecipeFromGroup(group: ItemGroup, owner: number): Recipe {
   return createRecipe({
     name: group.name,
     items: [...group.items],
-    owner: 3, // TODO: Get owner from somewhere (or create new Recipe type for data-only)
+    owner,
   })
 }

--- a/src/routes/test-app.tsx
+++ b/src/routes/test-app.tsx
@@ -4,7 +4,7 @@ import {
 } from '~/modules/diet/day-diet/application/dayDiet'
 import { type DayDiet } from '~/modules/diet/day-diet/domain/dayDiet'
 import { type Item } from '~/modules/diet/item/domain/item'
-import { type ItemGroup } from '~/modules/diet/item-group/domain/itemGroup'
+import { type ItemGroup, createSimpleItemGroup } from '~/modules/diet/item-group/domain/itemGroup'
 import { type Meal } from '~/modules/diet/meal/domain/meal'
 import { BackIcon } from '~/sections/common/components/icons/BackIcon'
 import { ConfirmModal } from '~/sections/common/components/ConfirmModal'
@@ -58,13 +58,11 @@ export default function TestApp() {
     reference: 31606,
   })
 
-  const [group, setGroup] = createSignal<ItemGroup>({
-    id: 1,
+  const [group, setGroup] = createSignal<ItemGroup>(createSimpleItemGroup({
     name: 'Teste',
     quantity: 100,
-    type: 'simple',
     items: [],
-  } satisfies ItemGroup)
+  }))
 
   createEffect(() => {
     setGroup({

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -197,7 +197,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
 
   createEffect(() => {
     const group_ = group()
-    if (group_.type !== 'recipe') {
+    if (group_.groupType !== 'recipe') {
       setRecipeSignal({ loading: false, errored: false, data: null })
       return
     }
@@ -213,7 +213,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
 
   createEffect(() => {
     const group_ = group()
-    const groupHasRecipe = group_?.type === 'recipe' && group_?.recipe !== null
+    const groupHasRecipe = group_?.groupType === 'recipe' && group_?.recipe !== null
     console.debug('Group changed:', group())
 
     if (groupHasRecipe) {
@@ -665,7 +665,7 @@ function Body(props: {
                   )}
                 </Show>
 
-                <Show when={group().type === 'simple'}>
+                <Show when={group().groupType === 'simple'}>
                   {(_) => (
                     <>
                       <button
@@ -722,7 +722,7 @@ function Body(props: {
                 <Show
                   when={(() => {
                     const group_ = group()
-                    return group_.type === 'recipe' && group_
+                    return group_.groupType === 'recipe' && group_
                   })()}
                 >
                   {(group) => (
@@ -863,7 +863,7 @@ function Body(props: {
           >
             Adicionar item
           </button>
-          {group().type === 'recipe' && group().recipe !== null && (
+          {group().groupType === 'recipe' && group().recipe !== null && (
             <PreparedQuantity
               // TODO: Remove as unknown as Accessor<RecipedItemGroup>
               recipedGroup={

--- a/src/sections/item-group/components/ItemGroupView.tsx
+++ b/src/sections/item-group/components/ItemGroupView.tsx
@@ -78,7 +78,7 @@ export function ItemGroupName(props: { group: Accessor<ItemGroup> }) {
   createEffect(() => {
     console.debug('[ItemGroupName] item changed, fetching API:', props.group)
     const group = props.group()
-    if (group?.type === 'recipe') {
+    if (group?.groupType === 'recipe') {
       recipeRepository
         .fetchRecipeById(group.recipe)
         .then((foundRecipe) => {
@@ -108,13 +108,13 @@ export function ItemGroupName(props: { group: Accessor<ItemGroup> }) {
       return 'text-red-900 bg-red-200 bg-opacity-50'
     }
 
-    if (group_.type === 'simple') {
+    if (group_.groupType === 'simple') {
       if (isSimpleSingleGroup(group_)) {
         return 'text-white'
       } else {
         return 'text-orange-400'
       }
-    } else if (group_.type === 'recipe' && recipe_.data !== null) {
+    } else if (group_.groupType === 'recipe' && recipe_.data !== null) {
       if (isRecipedGroupUpToDate(group_, recipe_.data)) {
         return 'text-yellow-200'
       } else {

--- a/src/sections/search/components/TemplateSearchModal.tsx
+++ b/src/sections/search/components/TemplateSearchModal.tsx
@@ -10,6 +10,8 @@ import {
   type ItemGroup,
   type RecipedItemGroup,
   type SimpleItemGroup,
+  createSimpleItemGroup,
+  createRecipedItemGroup,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 import { addId, generateId } from '~/legacy/utils/idUtils'
@@ -463,13 +465,11 @@ function ExternalItemEditModal(props: {
         onApply={(item) => {
           // TODO: Refactor conversion from template type to group/item types
           if (item.__type === 'Item') {
-            const newGroup: SimpleItemGroup = {
-              id: generateId(),
+            const newGroup: SimpleItemGroup = createSimpleItemGroup({
               name: item.name,
               items: [item],
-              type: 'simple',
               quantity: item.quantity,
-            }
+            })
             props.onNewItemGroup(newGroup, item).catch((err) => {
               console.error(err)
               toast.error(
@@ -477,14 +477,12 @@ function ExternalItemEditModal(props: {
               )
             })
           } else {
-            const newGroup: RecipedItemGroup = {
-              id: generateId(),
+            const newGroup: RecipedItemGroup = createRecipedItemGroup({
               name: item.name,
-              items: [...(props.selectedTemplate() as Recipe).items],
-              type: 'recipe',
-              quantity: item.quantity, // TODO: Implement quantity on recipe item groups (should influence macros)
               recipe: (props.selectedTemplate() as Recipe).id,
-            }
+              items: [...(props.selectedTemplate() as Recipe).items],
+              quantity: item.quantity, // TODO: Implement quantity on recipe item groups (should influence macros)
+            })
             props.onNewItemGroup(newGroup, item).catch((err) => {
               console.error(err)
               toast.error(


### PR DESCRIPTION
- Add createSimpleItemGroup() and createRecipedItemGroup() factory functions with JSDoc documentation
- Change ItemGroup schema discriminator from 'type' to 'groupType' to avoid naming conflicts
- Add __type field to ItemGroup schemas for better type identification
- Replace all manual ItemGroup object creation with factory functions across codebase
- Update itemGroupEditor, groupUtils, test files and UI components to use new schema structure
- Enhance recipe factory functions with improved documentation and explicit owner parameter
- Remove completed TODO comments related to issue #190

Resolves #190