### PR TITLE
Replace quantity field with calculated getter for ItemGroup

### DIFF
--- a/src/legacy/utils/data/itemGroupEditor.test.ts
+++ b/src/legacy/utils/data/itemGroupEditor.test.ts
@@ -23,7 +23,6 @@ function mockGroup(): ItemGroup {
   const group = createSimpleItemGroup({
     name: 'test:name',
     items: [],
-    quantity: 0,
   })
   // Override the generated ID for testing
   return { ...group, id: 1000 }

--- a/src/legacy/utils/data/itemGroupEditor.ts
+++ b/src/legacy/utils/data/itemGroupEditor.ts
@@ -20,11 +20,11 @@ export class ItemGroupEditor
 
   setRecipe(recipe: Recipe['id'] | undefined) {
     if (recipe === undefined) {
-      this.group.groupType = 'simple'
+      this.group.type = 'simple'
       this.group.recipe = undefined
       return this
     }
-    this.group.groupType = 'recipe'
+    this.group.type = 'recipe'
     this.group.recipe = recipe
     return this
   }
@@ -95,10 +95,6 @@ export class ItemGroupEditor
   }
 
   protected override onFinish() {
-    // TODO: Replace quantity field with a getter that calculates it
-    this.group.quantity = this.group.items.reduce(
-      (acc, item) => acc + item.quantity,
-      0,
-    )
+    // Quantity is now calculated on-demand via getItemGroupQuantity()
   }
 }

--- a/src/legacy/utils/groupUtils.ts
+++ b/src/legacy/utils/groupUtils.ts
@@ -3,6 +3,7 @@ import {
   type RecipedItemGroup,
   createSimpleItemGroup,
   createRecipedItemGroup,
+  getItemGroupQuantity,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { type Item } from '~/modules/diet/item/domain/item'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
@@ -52,13 +53,6 @@ export function isRecipedGroupUpToDate(
   return true
 }
 
-function calculateGroupQuantity(groupItems: ItemGroup['items']): number {
-  return groupItems
-    .map((item) => item.quantity)
-    .reduce((acc: number, quantity) => acc + quantity, 0)
-}
-
-// TODO: Replace quantity field with a getter that calculates it
 export function convertToGroups(convertible: GroupConvertible): ItemGroup[] {
   if (Array.isArray(convertible)) {
     return { ...convertible }
@@ -69,7 +63,6 @@ export function convertToGroups(convertible: GroupConvertible): ItemGroup[] {
       createRecipedItemGroup({
         name: convertible.name,
         items: [...convertible.items],
-        quantity: calculateGroupQuantity(convertible.items),
         recipe: convertible.id,
       }),
     ]
@@ -84,7 +77,6 @@ export function convertToGroups(convertible: GroupConvertible): ItemGroup[] {
       createSimpleItemGroup({
         name: convertible.name,
         items: [{ ...convertible } satisfies Item],
-        quantity: convertible.quantity,
       }),
     ]
   }

--- a/src/legacy/utils/groupUtils.ts
+++ b/src/legacy/utils/groupUtils.ts
@@ -3,11 +3,9 @@ import {
   type RecipedItemGroup,
   createSimpleItemGroup,
   createRecipedItemGroup,
-  getItemGroupQuantity,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { type Item } from '~/modules/diet/item/domain/item'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
-import { generateId } from '~/legacy/utils/idUtils'
 
 export type GroupConvertible =
   | ItemGroup

--- a/src/modules/diet/day-diet/application/dayDiet.ts
+++ b/src/modules/diet/day-diet/application/dayDiet.ts
@@ -13,6 +13,7 @@ import { createEffect, createSignal } from 'solid-js'
 import { currentUserId } from '~/modules/user/application/user'
 import toast from 'solid-toast'
 import { registerSubapabaseRealtimeCallback } from '~/legacy/utils/supabase'
+import { formatError } from '~/shared/formatError'
 
 export function createDayDiet({
   target_day: targetDay,
@@ -104,8 +105,7 @@ export async function __unused_refetchCurrentDayDiet() {
     })
     .catch((error) => {
       toast.error(
-        'Falha na comunicação com o servidor ao buscar dieta do dia: \n' +
-          JSON.stringify(error, null, 2),
+        `Falha na comunicação com o servidor ao buscar dieta do dia: ${formatError(error)}`,
       )
       console.error(error)
     })
@@ -120,8 +120,9 @@ export async function fetchAllUserDayDiets(userId: User['id']) {
     })
     .catch((error) => {
       toast.error(
-        'Falha na comunicação com o servidor ao buscar dieta dos dias do usuário',
+        `Falha na comunicação com o servidor ao buscar dieta dos dias do usuário: ${formatError(error)}`,
       )
+
       console.error(error)
     })
 }

--- a/src/modules/diet/food/infrastructure/api/infrastructure/utils.ts
+++ b/src/modules/diet/food/infrastructure/api/infrastructure/utils.ts
@@ -9,7 +9,6 @@
 // } from '~/legacy/api/apiSecrets'
 
 // export const searchFoodNameInternal = async (food: string) => {
-//   return JSON.stringify('oi')
 
 //   const url = `${EXTERNAL_API_BASE_URL}/${EXTERNAL_API_FOOD_ENDPOINT}`
 //   const response = await axios.get(url, {

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -37,6 +37,7 @@ import {
 } from 'solid-js'
 import { Alert } from '~/sections/common/components/Alert'
 import toast from 'solid-toast'
+import { formatError } from '~/shared/formatError'
 
 type EditSelection = {
   meal: Meal
@@ -185,8 +186,7 @@ export default function DayMeals(props: { selectedDay: string }) {
                       handleUpdateMeal(currentDayDiet_, meal).catch((e) => {
                         console.error(e)
                         toast.error(
-                          'Erro ao atualizar refeição: \n' +
-                            JSON.stringify(e, null, 2),
+                          `Erro ao atualizar refeição: ${formatError(e)}`,
                         )
                       })
                     }}
@@ -255,12 +255,6 @@ function ExternalItemGroupEditModal(props: {
               editSelection().meal.name ?? 'ERROR: No meal selected'
             }
             onSaveGroup={(group) => {
-              console.debug(
-                `[DayMeals] (<ItemGroupEditModal/>) Saving group: ${JSON.stringify(
-                  group,
-                )}`,
-              )
-
               updateItemGroup(
                 props.day().id,
                 editSelection().meal.id,

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -4,6 +4,7 @@ import {
   isSimpleSingleGroup,
   itemGroupSchema,
   recipedItemGroupSchema,
+  getItemGroupQuantity,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { Modal, ModalActions } from '~/sections/common/components/Modal'
 import { ItemListView } from '~/sections/food-item/components/ItemListView'
@@ -181,11 +182,6 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
       .addItem(newGroup.items[0])
       .finish()
 
-    console.debug(
-      'handleNewItemGroup: applying',
-      JSON.stringify(finalGroup, null, 2),
-    )
-
     setGroup(finalGroup)
   }
 
@@ -197,7 +193,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
 
   createEffect(() => {
     const group_ = group()
-    if (group_.groupType !== 'recipe') {
+    if (group_.type !== 'recipe') {
       setRecipeSignal({ loading: false, errored: false, data: null })
       return
     }
@@ -213,7 +209,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
 
   createEffect(() => {
     const group_ = group()
-    const groupHasRecipe = group_?.groupType === 'recipe' && group_?.recipe !== null
+    const groupHasRecipe = group_?.type === 'recipe' && group_?.recipe !== null
     console.debug('Group changed:', group())
 
     if (groupHasRecipe) {
@@ -665,7 +661,7 @@ function Body(props: {
                   )}
                 </Show>
 
-                <Show when={group().groupType === 'simple'}>
+                <Show when={group().type === 'simple'}>
                   {(_) => (
                     <>
                       <button
@@ -722,7 +718,7 @@ function Body(props: {
                 <Show
                   when={(() => {
                     const group_ = group()
-                    return group_.groupType === 'recipe' && group_
+                    return group_.type === 'recipe' && group_
                   })()}
                 >
                   {(group) => (
@@ -863,7 +859,7 @@ function Body(props: {
           >
             Adicionar item
           </button>
-          {group().groupType === 'recipe' && group().recipe !== null && (
+          {group().type === 'recipe' && group().recipe !== null && (
             <PreparedQuantity
               // TODO: Remove as unknown as Accessor<RecipedItemGroup>
               recipedGroup={
@@ -964,10 +960,10 @@ function PreparedQuantity(props: {
   setRecipedGroup: Setter<RecipedItemGroup | null>
   recipe: Recipe | null
 }) {
-  const rawQuantity = () =>
-    props.recipedGroup()?.items.reduce((acc, item) => {
-      return acc + item.quantity
-    }, 0)
+  const rawQuantity = () => {
+    const group = props.recipedGroup()
+    return group ? getItemGroupQuantity(group) : 0
+  }
 
   const initialPreparedQuantity = () =>
     (rawQuantity() ?? 0) * (props.recipe?.prepared_multiplier ?? 1)

--- a/src/sections/item-group/components/ItemGroupView.tsx
+++ b/src/sections/item-group/components/ItemGroupView.tsx
@@ -184,7 +184,7 @@ export function ItemGroupViewNutritionalInfo(props: {
     <div class="flex">
       <MacroNutrientsView macros={multipliedMacros()} />
       <div class="ml-auto">
-        <span class="text-white"> {props.group() ? getItemGroupQuantity(props.group()) : -666}g </span>|
+        <span class="text-white"> {getItemGroupQuantity(props.group())}g </span>|
         <span class="text-white">
           {' '}
           {calcGroupCalories(props.group()).toFixed(0)}

--- a/src/sections/item-group/components/ItemGroupView.tsx
+++ b/src/sections/item-group/components/ItemGroupView.tsx
@@ -4,6 +4,7 @@ import { CopyIcon } from '~/sections/common/components/icons/CopyIcon'
 import {
   type ItemGroup,
   isSimpleSingleGroup,
+  getItemGroupQuantity,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { calcGroupCalories, calcGroupMacros } from '~/legacy/utils/macroMath'
 import { isRecipedGroupUpToDate } from '~/legacy/utils/groupUtils'
@@ -78,7 +79,7 @@ export function ItemGroupName(props: { group: Accessor<ItemGroup> }) {
   createEffect(() => {
     console.debug('[ItemGroupName] item changed, fetching API:', props.group)
     const group = props.group()
-    if (group?.groupType === 'recipe') {
+    if (group?.type === 'recipe') {
       recipeRepository
         .fetchRecipeById(group.recipe)
         .then((foundRecipe) => {
@@ -108,13 +109,13 @@ export function ItemGroupName(props: { group: Accessor<ItemGroup> }) {
       return 'text-red-900 bg-red-200 bg-opacity-50'
     }
 
-    if (group_.groupType === 'simple') {
+    if (group_.type === 'simple') {
       if (isSimpleSingleGroup(group_)) {
         return 'text-white'
       } else {
         return 'text-orange-400'
       }
-    } else if (group_.groupType === 'recipe' && recipe_.data !== null) {
+    } else if (group_.type === 'recipe' && recipe_.data !== null) {
       if (isRecipedGroupUpToDate(group_, recipe_.data)) {
         return 'text-yellow-200'
       } else {
@@ -183,7 +184,7 @@ export function ItemGroupViewNutritionalInfo(props: {
     <div class="flex">
       <MacroNutrientsView macros={multipliedMacros()} />
       <div class="ml-auto">
-        <span class="text-white"> {props.group()?.quantity ?? -666}g </span>|
+        <span class="text-white"> {props.group() ? getItemGroupQuantity(props.group()) : -666}g </span>|
         <span class="text-white">
           {' '}
           {calcGroupCalories(props.group()).toFixed(0)}

--- a/src/sections/macro-nutrients/components/MacroTargets.tsx
+++ b/src/sections/macro-nutrients/components/MacroTargets.tsx
@@ -23,6 +23,7 @@ import toast from 'solid-toast'
 import { currentUserId } from '~/modules/user/application/user'
 import { targetDay } from '~/modules/diet/day-diet/application/dayDiet'
 import { type MacroNutrients } from '~/modules/diet/macro-nutrients/domain/macroNutrients'
+import { formatError } from '~/shared/formatError'
 
 const CARBO_CALORIES = 4 as const
 const PROTEIN_CALORIES = 4 as const
@@ -241,8 +242,7 @@ export function MacroTarget(props: MacroTargetProps) {
                                       })
                                       .catch((e) => {
                                         toast.error(
-                                          'Erro ao apagar perfil atual: \n' +
-                                            JSON.stringify(e, null, 2),
+                                          `Erro ao restaurar perfil antigo: ${formatError(e)}`,
                                         )
                                       })
                                   },

--- a/src/sections/profile/components/UserInfo.tsx
+++ b/src/sections/profile/components/UserInfo.tsx
@@ -11,6 +11,7 @@ import {
 import { currentUser, updateUser } from '~/modules/user/application/user'
 import { convertString, UserInfoCapsule } from './UserInfoCapsule'
 import toast from 'solid-toast'
+import { formatError } from '~/shared/formatError'
 type Translation<T extends string> = { [key in T]: string }
 // TODO: Create module for translations
 // TODO: Make diet translations appear in the UI
@@ -105,7 +106,7 @@ export function UserInfo() {
           updateUser(newUser.id, newUser).catch((error) => {
             console.error(error)
             toast.error(
-              'Erro ao salvar usuário: \n' + JSON.stringify(error, null, 2),
+              `Erro ao atualizar usuário: ${formatError(error)}`,
             )
           })
         }}

--- a/src/sections/profile/measure/components/MeasureView.tsx
+++ b/src/sections/profile/measure/components/MeasureView.tsx
@@ -11,6 +11,7 @@ import {
 } from '~/modules/measure/application/measure'
 import { createMirrorSignal } from '~/sections/common/hooks/createMirrorSignal'
 import toast from 'solid-toast'
+import { formatError } from '~/shared/formatError'
 
 export function MeasureView(props: {
   measure: Measure
@@ -64,7 +65,9 @@ export function MeasureView(props: {
       .then(afterUpdate)
       .catch((error) => {
         console.error(error)
-        toast.error('Erro ao salvar: \n' + JSON.stringify(error, null, 2))
+        toast.error(
+          `Erro ao atualizar medida: ${formatError(error)}`
+        )
       })
   }
 

--- a/src/sections/profile/measure/components/MeasuresEvolution.tsx
+++ b/src/sections/profile/measure/components/MeasuresEvolution.tsx
@@ -12,6 +12,7 @@ import {
 } from '~/modules/measure/application/measure'
 import toast from 'solid-toast'
 import { CARD_BACKGROUND_COLOR, CARD_STYLE } from '~/modules/theme/constants'
+import { formatError } from '~/shared/formatError'
 
 export function MeasuresEvolution() {
   // TODO: Remove `measures` signal and use use cases instead
@@ -133,8 +134,7 @@ export function MeasuresEvolution() {
                 .catch((error) => {
                   console.error(error)
                   toast.error(
-                    'Erro ao adicionar peso: \n' +
-                      JSON.stringify(error, null, 2),
+                    `Erro ao adicionar medida: ${formatError(error)}`,
                   )
                 })
             }}

--- a/src/sections/search/components/TemplateSearchModal.tsx
+++ b/src/sections/search/components/TemplateSearchModal.tsx
@@ -68,6 +68,7 @@ import {
   templateSearchTab,
   setTemplateSearch,
 } from '~/modules/search/application/search'
+import { formatError } from '~/shared/formatError'
 
 export type TemplateSearchModalProps = {
   targetName: string
@@ -202,7 +203,7 @@ export function TemplateSearchModal(props: TemplateSearchModalProps) {
               onConfirm().catch((err) => {
                 console.error(err)
                 toast.error(
-                  'Erro ao adicionar item: \n' + JSON.stringify(err, null, 2),
+                  `Erro ao adicionar item: ${formatError(err)}`,
                 )
               })
             },
@@ -220,7 +221,7 @@ export function TemplateSearchModal(props: TemplateSearchModalProps) {
         await onConfirm()
       } catch (err) {
         console.error(err)
-        toast.error('Erro ao adicionar item: \n' + JSON.stringify(err, null, 2))
+        toast.error(`Erro ao adicionar item: ${formatError(err)}`)
       }
     }
   }
@@ -427,7 +428,7 @@ export function TemplateSearch(props: {
           setItemEditModalVisible={props.setItemEditModalVisible}
           setSelectedTemplate={props.setSelectedTemplate}
           typing={typing}
-          refetch={refetch}
+          refetch={async () => { await refetch(); }}
         />
       </Suspense>
     </>
@@ -468,12 +469,11 @@ function ExternalItemEditModal(props: {
             const newGroup: SimpleItemGroup = createSimpleItemGroup({
               name: item.name,
               items: [item],
-              quantity: item.quantity,
             })
             props.onNewItemGroup(newGroup, item).catch((err) => {
               console.error(err)
               toast.error(
-                'Erro ao adicionar item: \n' + JSON.stringify(err, null, 2),
+                `Erro ao adicionar item: ${formatError(err)}`,
               )
             })
           } else {
@@ -481,12 +481,11 @@ function ExternalItemEditModal(props: {
               name: item.name,
               recipe: (props.selectedTemplate() as Recipe).id,
               items: [...(props.selectedTemplate() as Recipe).items],
-              quantity: item.quantity, // TODO: Implement quantity on recipe item groups (should influence macros)
             })
             props.onNewItemGroup(newGroup, item).catch((err) => {
               console.error(err)
               toast.error(
-                'Erro ao adicionar item: \n' + JSON.stringify(err, null, 2),
+                `Erro ao adicionar item: ${formatError(err)}`,
               )
             })
           }

--- a/src/sections/search/components/TemplateSearchResults.tsx
+++ b/src/sections/search/components/TemplateSearchResults.tsx
@@ -26,7 +26,7 @@ export function TemplateSearchResults(props: {
   setSelectedTemplate: (food: Template) => void
   barCodeModalVisible: Accessor<boolean>
   setBarCodeModalVisible: Setter<boolean>
-  ItemEditModalVisible: Accessor<boolean>
+  itemEditModalVisible: Accessor<boolean>
   setItemEditModalVisible: Setter<boolean>
   refetch: () => Promise<void>
 }) {

--- a/src/sections/weight/components/WeightEvolution.tsx
+++ b/src/sections/weight/components/WeightEvolution.tsx
@@ -25,6 +25,7 @@ import { type ApexOptions } from 'apexcharts'
 import toast from 'solid-toast'
 import ptBrLocale from '~/assets/locales/apex/pt-br.json'
 import { CARD_BACKGROUND_COLOR, CARD_STYLE } from '~/modules/theme/constants'
+import { formatError } from '~/shared/formatError'
 
 export function WeightEvolution() {
   const desiredWeight = () => currentUser()?.desired_weight ?? 0
@@ -89,7 +90,7 @@ export function WeightEvolution() {
                 .catch((error) => {
                   console.error(error)
                   toast.error(
-                    'Erro ao adicionar: \n' + JSON.stringify(error, null, 2),
+                    `Erro ao adicionar peso: ${formatError(error)}`,
                   )
                 })
             }}
@@ -206,7 +207,7 @@ function WeightView(props: { weight: Weight }) {
               deleteWeight(props.weight.id).catch((error) => {
                 console.error(error)
                 toast.error(
-                  'Erro ao deletar: \n' + JSON.stringify(error, null, 2),
+                  `Erro ao deletar peso: ${formatError(error)}`,
                 )
               })
             }}

--- a/src/shared/formatError.ts
+++ b/src/shared/formatError.ts
@@ -1,0 +1,45 @@
+import { ZodError } from 'zod'
+
+export interface ZodErrorInfo {
+  name: 'ZodError'
+  issues: Array<{
+    code: string
+    message: string
+    path: (string | number)[]
+    options?: string[]
+  }>
+}
+
+export function isZodError(error: unknown): error is ZodError {
+  return error instanceof ZodError || 
+         (typeof error === 'object' && 
+          error !== null && 
+          'name' in error && 
+          error.name === 'ZodError' &&
+          'issues' in error)
+}
+
+export function getZodErrorMessage(error: ZodError): string {
+  const issues = error.issues.map(issue => {
+    const path = issue.path.length > 0 ? ` at ${issue.path.join('.')}` : ''
+    return `${issue.message}${path}`
+  }).join('; ')
+  
+  return `Validation error: ${issues}`
+}
+
+export function formatError(error: unknown): string {
+  if (isZodError(error)) {
+    return getZodErrorMessage(error as ZodError)
+  }
+  
+  if (error instanceof Error) {
+    return error.message
+  }
+  
+  if (typeof error === 'string') {
+    return error
+  }
+  
+  return `Unknown error: ${JSON.stringify(error, null, 2)}`
+}

--- a/src/shared/formatError.ts
+++ b/src/shared/formatError.ts
@@ -1,15 +1,5 @@
 import { ZodError } from 'zod'
 
-export interface ZodErrorInfo {
-  name: 'ZodError'
-  issues: Array<{
-    code: string
-    message: string
-    path: (string | number)[]
-    options?: string[]
-  }>
-}
-
 export function isZodError(error: unknown): error is ZodError {
   return error instanceof ZodError || 
          (typeof error === 'object' && 


### PR DESCRIPTION
Remove the explicit quantity field from ItemGroup schemas and implement a getter to calculate quantity on-demand. This change enhances maintainability and ensures that quantity is always accurate based on actual item quantities. Additionally, improve error handling across various components for better user experience.

Fixes #407