### PR TITLE
Refactor clipboard actions to use useClipboard hook

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,4 +81,7 @@ coding standards and passing all tests before submitting a pull request.
 - Use consistent naming conventions for all identifiers.
 - Do not modify `.eslintrc.cjs` or `.github/copilot-instructions.md` without user consent.
 
+## Imports
+- Never use dynamic/inline imports (e.g., `import('~/sections/common/context/ConfirmModalContext')`). Always use static imports at the top of the file.
+
 This file should not be modified directly without user consent.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.63.3+issue.472",
+  "version": "v0.11.0-dev.64.4+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.61.1+issue.472",
+  "version": "v0.11.0-dev.62.2+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.62.2+issue.472",
+  "version": "v0.11.0-dev.63.3+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.58.18+issue.506",
+  "version": "v0.11.0-dev.0+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.65.5+issue.472",
+  "version": "v0.11.0-dev.66.6+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.64.4+issue.472",
+  "version": "v0.11.0-dev.65.5+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.0+issue.472",
+  "version": "v0.11.0-dev.61.1+issue.472",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/src/sections/common/hooks/useClipboard.tsx
+++ b/src/sections/common/hooks/useClipboard.tsx
@@ -1,5 +1,6 @@
 import { createEffect, createSignal } from 'solid-js'
 import { type z } from 'zod'
+import { isClipboardNotAllowedError } from '~/shared/error/isClipboardNotAllowedError'
 
 export type ClipboardFilter = (clipboard: string) => boolean
 
@@ -11,12 +12,19 @@ export function useClipboard(props?: {
   const periodicRead = () => props?.periodicRead ?? true
   const [clipboard, setClipboard] = createSignal('')
 
-  const handleWrite = (text: string) => {
+  const handleWrite = (
+    text: string,
+    onError?: (error: unknown) => void
+  ) => {
     window.navigator.clipboard
       .writeText(text)
       .then(() => setClipboard(text))
-      .catch(() => {
-        // Do nothing. This is expected when the DOM is not focused
+      .catch((err) => {
+        if (isClipboardNotAllowedError(err)) {
+          // Ignore NotAllowedError (likely DOM not focused)
+          return
+        }
+        if (onError) onError(err)
       })
   }
 

--- a/src/sections/common/hooks/useClipboard.tsx
+++ b/src/sections/common/hooks/useClipboard.tsx
@@ -1,6 +1,13 @@
 import { createEffect, createSignal } from 'solid-js'
 import { type z } from 'zod'
-import { isClipboardNotAllowedError } from '~/shared/error/isClipboardNotAllowedError'
+
+// Utility to check if an error is a NotAllowedError DOMException
+function isClipboardNotAllowedError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    error.name === 'NotAllowedError'
+  )
+}
 
 export type ClipboardFilter = (clipboard: string) => boolean
 

--- a/src/sections/common/hooks/useCopyPasteActions.ts
+++ b/src/sections/common/hooks/useCopyPasteActions.ts
@@ -1,0 +1,64 @@
+import { useClipboard, createClipboardSchemaFilter } from '~/sections/common/hooks/useClipboard'
+import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
+import { deserializeClipboard } from '~/legacy/utils/clipboardUtils'
+import { Accessor } from 'solid-js'
+
+/**
+ * Shared clipboard copy/paste logic for meal/recipe editors.
+ * @param options
+ *   - acceptedClipboardSchema: zod schema for validation
+ *   - getDataToCopy: function to get the data to copy
+ *   - onPaste: function to handle parsed clipboard data
+ */
+export function useCopyPasteActions<T>({
+  acceptedClipboardSchema,
+  getDataToCopy,
+  onPaste,
+}: {
+  acceptedClipboardSchema: any
+  getDataToCopy: () => T
+  onPaste: (data: unknown) => void
+}) {
+  const { show: showConfirmModal } = useConfirmModalContext()
+  const isClipboardValid = createClipboardSchemaFilter(acceptedClipboardSchema)
+  const {
+    clipboard: clipboardText,
+    write: writeToClipboard,
+    clear: clearClipboard,
+  } = useClipboard({ filter: isClipboardValid })
+
+  const handleCopy = () => {
+    writeToClipboard(JSON.stringify(getDataToCopy()))
+  }
+
+  const handlePasteAfterConfirm = () => {
+    const data = deserializeClipboard(clipboardText(), acceptedClipboardSchema)
+    if (data === null) {
+      throw new Error('Invalid clipboard data: ' + clipboardText())
+    }
+    onPaste(data)
+    clearClipboard()
+  }
+
+  const handlePaste = () => {
+    showConfirmModal({
+      title: 'Colar itens',
+      body: 'Tem certeza que deseja colar os itens?',
+      actions: [
+        { text: 'Cancelar', onClick: () => undefined },
+        { text: 'Colar', primary: true, onClick: handlePasteAfterConfirm },
+      ],
+    })
+  }
+
+  const hasValidPastableOnClipboard = () => isClipboardValid(clipboardText())
+
+  return {
+    clipboardText,
+    writeToClipboard,
+    clearClipboard,
+    handleCopy,
+    handlePaste,
+    hasValidPastableOnClipboard,
+  }
+}

--- a/src/sections/common/hooks/useCopyPasteActions.ts
+++ b/src/sections/common/hooks/useCopyPasteActions.ts
@@ -1,7 +1,6 @@
 import { useClipboard, createClipboardSchemaFilter } from '~/sections/common/hooks/useClipboard'
 import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 import { deserializeClipboard } from '~/legacy/utils/clipboardUtils'
-import { Accessor } from 'solid-js'
 
 /**
  * Shared clipboard copy/paste logic for meal/recipe editors.

--- a/src/sections/food-item/components/ItemListView.tsx
+++ b/src/sections/food-item/components/ItemListView.tsx
@@ -47,7 +47,16 @@ function DefaultHeader() {
       copyButton={
         <ItemCopyButton
           onCopyItem={(item) => {
-            clipboard.write(JSON.stringify(item))
+            clipboard.write(
+              JSON.stringify(item),
+              (error) => {
+                handleClipboardError(error, {
+                  component: 'ItemListView',
+                  operation: 'copyItem',
+                  additionalData: { itemId: item.reference },
+                })
+              }
+            )
           }}
         />
       }

--- a/src/sections/food-item/components/ItemListView.tsx
+++ b/src/sections/food-item/components/ItemListView.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/sections/food-item/components/ItemView'
 import { mergeProps, type Accessor, For } from 'solid-js'
 import { handleClipboardError } from '~/shared/error/errorHandler'
+import { useClipboard } from '~/sections/common/hooks/useClipboard'
 
 export function ItemListView(_props: {
   items: Accessor<readonly Item[]>
@@ -39,19 +40,14 @@ export function ItemListView(_props: {
 }
 
 function DefaultHeader() {
+  const clipboard = useClipboard()
   return (
     <ItemHeader
       name={<ItemName />}
       copyButton={
         <ItemCopyButton
           onCopyItem={(item) => {
-            navigator.clipboard.writeText(JSON.stringify(item)).catch((error) => {
-              handleClipboardError(error, { 
-                component: 'ItemListView',
-                operation: 'copyItem',
-                additionalData: { itemId: item.reference }
-              })
-            })
+            clipboard.write(JSON.stringify(item))
           }}
         />
       }

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -78,6 +78,7 @@ import {
   insertRecipe,
 } from '~/modules/diet/recipe/application/recipe'
 import { BrokenLink } from '~/sections/common/components/icons/BrokenLinkIcon'
+import { useCopyPasteActions } from '~/sections/common/hooks/useCopyPasteActions'
 
 type EditSelection = {
   item: Item
@@ -469,75 +470,38 @@ function Body(props: {
   templateSearchModalVisible: Accessor<boolean>
   setTemplateSearchModalVisible: Setter<boolean>
 }) {
+  const { show: showConfirmModal } = useConfirmModalContext()
+
   const acceptedClipboardSchema = itemSchema.or(itemGroupSchema)
-
   const { group, setGroup } = useItemGroupEditContext()
-
   const recipedGroup = createMemo(() => {
     const currentGroup = group()
     return currentGroup.type === 'recipe' && currentGroup.recipe !== null ? currentGroup : null
   })
 
   const {
-    write: writeToClipboard,
-    clear: clearClipboard,
-    clipboard: clipboardText,
-  } = useClipboard({
-    filter: (clipboard) => {
-      if (clipboard === '') return false
-      let parsedClipboard: unknown
-      try {
-        parsedClipboard = JSON.parse(clipboard)
-      } catch (e) {
-        // Error parsing JSON. Probably clipboard is some random text from the user
-        return false
+    writeToClipboard,
+    handlePaste: handlePasteShared,
+    hasValidPastableOnClipboard: hasValidPastableOnClipboardShared,
+  } = useCopyPasteActions({
+    acceptedClipboardSchema,
+    getDataToCopy: () => group(),
+    onPaste: (data: any) => {
+      const group_ = group()
+      if ('items' in data) {
+        // data is an itemGroup
+        const newGroup = new ItemGroupEditor(group_)
+          .addItems(data.items.map((item: any) => regenerateId(item)))
+          .finish()
+        setGroup(newGroup)
+      } else {
+        const newGroup = new ItemGroupEditor(group_)
+          .addItem(regenerateId(data))
+          .finish()
+        setGroup(newGroup)
       }
-
-      return acceptedClipboardSchema.safeParse(parsedClipboard).success
     },
   })
-  const { show: showConfirmModal } = useConfirmModalContext()
-
-  const hasValidPastableOnClipboard = () => clipboardText().length > 0
-
-  const handlePasteAfterConfirm = () => {
-    const data = deserializeClipboard(clipboardText(), acceptedClipboardSchema)
-
-    if (data === null) {
-      throw new Error('Invalid clipboard data: ' + clipboardText())
-    }
-    const group_ = group()
-
-    if ('items' in data) {
-      // data is an itemGroup
-      const newGroup = new ItemGroupEditor(group_)
-        .addItems(data.items.map((item) => regenerateId(item)))
-        .finish()
-      setGroup(newGroup)
-    } else {
-      const newGroup = new ItemGroupEditor(group_)
-        .addItem(regenerateId(data))
-        .finish()
-      setGroup(newGroup)
-    }
-
-    // Clear clipboard
-    clearClipboard()
-  }
-
-  const handlePaste = () => {
-    showConfirmModal({
-      title: 'Colar itens',
-      body: 'Tem certeza que deseja colar os itens?',
-      actions: [
-        {
-          text: 'Cancelar',
-          onClick: () => undefined,
-        },
-        { text: 'Colar', primary: true, onClick: handlePasteAfterConfirm },
-      ],
-    })
-  }
 
   return (
     <Show when={group()}>
@@ -566,7 +530,7 @@ function Body(props: {
               </div>
 
               <div class="flex gap-2 px-2">
-                <Show when={hasValidPastableOnClipboard()}>
+                <Show when={hasValidPastableOnClipboardShared()}>
                   {(_) => (
                     <div
                       class={
@@ -579,8 +543,7 @@ function Body(props: {
                           )
                           return
                         }
-
-                        handlePaste()
+                        handlePasteShared()
                       }}
                     >
                       <PasteIcon />

--- a/src/sections/item-group/components/ItemGroupListView.tsx
+++ b/src/sections/item-group/components/ItemGroupListView.tsx
@@ -38,7 +38,7 @@ export function ItemGroupListView(props: {
                           (err) => {
                             handleClipboardError(err, {
                               component: 'ItemGroupListView',
-                              operation: 'copy item group',
+                              operation: 'copyItemGroup',
                               additionalData: { groupId: group.id },
                             })
                           }

--- a/src/sections/item-group/components/ItemGroupListView.tsx
+++ b/src/sections/item-group/components/ItemGroupListView.tsx
@@ -7,13 +7,14 @@ import {
   ItemGroupViewNutritionalInfo,
   type ItemGroupViewProps,
 } from '~/sections/item-group/components/ItemGroupView'
-import { handleClipboardError } from '~/shared/error/errorHandler'
+import { useClipboard } from '~/sections/common/hooks/useClipboard'
 import { type Accessor } from 'solid-js'
 
 export function ItemGroupListView(props: {
   itemGroups: Accessor<ItemGroup[]>
   onItemClick: ItemGroupViewProps['onClick']
 }) {
+  const clipboard = useClipboard()
   console.debug('[ItemGroupListView] - Rendering')
   return (
     <>
@@ -31,16 +32,7 @@ export function ItemGroupListView(props: {
                     <ItemGroupCopyButton
                       group={group}
                       onCopyItemGroup={(group) => {
-                        // TODO: Replace with clipboard hook (here and in ItemView, if applicable)
-                        navigator.clipboard
-                          .writeText(JSON.stringify(group))
-                          .catch((err) => {
-                            handleClipboardError(err, {
-                              component: 'ItemGroupListView',
-                              operation: 'copy item group',
-                              additionalData: { groupId: group.id }
-                            })
-                          })
+                        clipboard.write(JSON.stringify(group))
                       }}
                     />
                   }

--- a/src/sections/item-group/components/ItemGroupListView.tsx
+++ b/src/sections/item-group/components/ItemGroupListView.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/sections/item-group/components/ItemGroupView'
 import { useClipboard } from '~/sections/common/hooks/useClipboard'
 import { type Accessor } from 'solid-js'
+import { handleClipboardError } from '~/shared/error/errorHandler'
 
 export function ItemGroupListView(props: {
   itemGroups: Accessor<ItemGroup[]>
@@ -32,7 +33,16 @@ export function ItemGroupListView(props: {
                     <ItemGroupCopyButton
                       group={group}
                       onCopyItemGroup={(group) => {
-                        clipboard.write(JSON.stringify(group))
+                        clipboard.write(
+                          JSON.stringify(group),
+                          (err) => {
+                            handleClipboardError(err, {
+                              component: 'ItemGroupListView',
+                              operation: 'copy item group',
+                              additionalData: { groupId: group.id },
+                            })
+                          }
+                        )
                       }}
                     />
                   }

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -8,11 +8,7 @@ import {
   type ItemGroup,
   itemGroupSchema,
 } from '~/modules/diet/item-group/domain/itemGroup'
-import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
-import {
-  useClipboard,
-  createClipboardSchemaFilter,
-} from '~/sections/common/hooks/useClipboard'
+import { useCopyPasteActions } from '~/sections/common/hooks/useCopyPasteActions'
 import { deserializeClipboard } from '~/legacy/utils/clipboardUtils'
 import { convertToGroups } from '~/modules/diet/item-group/application/itemGroupService'
 import { regenerateId } from '~/legacy/utils/idUtils'
@@ -67,70 +63,35 @@ export function MealEditView(props: MealEditViewProps) {
 export function MealEditViewHeader(props: {
   onUpdateMeal: (meal: Meal) => void
 }) {
+  const { meal } = useMealContext()
   const acceptedClipboardSchema = mealSchema
     .or(itemGroupSchema)
     .or(itemSchema)
     .or(recipeSchema)
-  const { show: showConfirmModal } = useConfirmModalContext()
-  const { meal } = useMealContext()
-
-  const isClipboardValid = createClipboardSchemaFilter(acceptedClipboardSchema)
 
   const {
-    clipboard: clipboardText,
-    write: writeToClipboard,
-    clear: clearClipboard,
-  } = useClipboard({
-    filter: isClipboardValid,
+    handleCopy,
+    handlePaste,
+    hasValidPastableOnClipboard,
+  } = useCopyPasteActions({
+    acceptedClipboardSchema,
+    getDataToCopy: () => meal(),
+    onPaste: (data) => {
+      const meal_ = meal()
+      if (meal_ === null) {
+        throw new Error('mealSignal is null!')
+      }
+      const groupsToAdd = convertToGroups(data)
+        .map((group) => regenerateId(group))
+        .map((g) => ({
+          ...g,
+          items: g.items.map((item) => regenerateId(item)),
+        }))
+      const newMeal = new MealEditor(meal_).addGroups(groupsToAdd).finish()
+      props.onUpdateMeal(newMeal)
+    },
   })
 
-  const handleCopy = () => {
-    writeToClipboard(JSON.stringify(meal()))
-  }
-
-  // TODO: Remove code duplication between MealEditView and RecipeView
-  const handlePasteAfterConfirm = () => {
-    const data = deserializeClipboard(clipboardText(), acceptedClipboardSchema)
-
-    if (data === null) {
-      throw new Error('Invalid clipboard data: ' + clipboardText())
-    }
-
-    const meal_ = meal()
-    if (meal_ === null) {
-      throw new Error('mealSignal is null!')
-    }
-
-    const groupsToAdd = convertToGroups(data)
-      .map((group) => regenerateId(group))
-      .map((g) => ({
-        ...g,
-        items: g.items.map((item) => regenerateId(item)),
-      }))
-
-    const newMeal = new MealEditor(meal_).addGroups(groupsToAdd).finish()
-
-    props.onUpdateMeal(newMeal)
-
-    // Clear clipboard
-    clearClipboard()
-  }
-
-  const handlePaste = () => {
-    showConfirmModal({
-      title: 'Colar itens',
-      body: 'Tem certeza que deseja colar os itens?',
-      actions: [
-        {
-          text: 'Cancelar',
-          onClick: () => undefined,
-        },
-        { text: 'Colar', primary: true, onClick: handlePasteAfterConfirm },
-      ],
-    })
-  }
-
-  // TODO: Show how much of the daily target is this meal (e.g. 30% of daily calories) (maybe in a tooltip) (useContext)s
   const mealCalories = () => {
     const meal_ = meal()
     if (meal_ === null) {
@@ -141,34 +102,30 @@ export function MealEditViewHeader(props: {
 
   const onClearItems = (e: MouseEvent) => {
     e.preventDefault()
-
-    showConfirmModal({
-      title: 'Limpar itens',
-      body: 'Tem certeza que deseja limpar os itens?',
-      actions: [
-        {
-          text: 'Cancelar',
-          onClick: () => undefined,
-        },
-        {
-          text: 'Excluir todos os itens',
-          primary: true,
-          onClick: () => {
-            const meal_ = meal()
-            if (meal_ === null) {
-              throw new Error('meal_ is null!')
-            }
-
-            const newMeal = new MealEditor(meal_).clearGroups().finish()
-
-            props.onUpdateMeal(newMeal)
+    // This logic is not duplicated with RecipeEditView, so keep it here
+    import('~/sections/common/context/ConfirmModalContext').then(({ useConfirmModalContext }) => {
+      const { show: showConfirmModal } = useConfirmModalContext()
+      showConfirmModal({
+        title: 'Limpar itens',
+        body: 'Tem certeza que deseja limpar os itens?',
+        actions: [
+          { text: 'Cancelar', onClick: () => undefined },
+          {
+            text: 'Excluir todos os itens',
+            primary: true,
+            onClick: () => {
+              const meal_ = meal()
+              if (meal_ === null) {
+                throw new Error('meal_ is null!')
+              }
+              const newMeal = new MealEditor(meal_).clearGroups().finish()
+              props.onUpdateMeal(newMeal)
+            },
           },
-        },
-      ],
+        ],
+      })
     })
   }
-
-  const hasValidPastableOnClipboard = () => isClipboardValid(clipboardText())
 
   return (
     <Show when={meal()}>

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -21,6 +21,7 @@ import {
 } from '~/sections/meal/context/MealContext'
 // TODO: Remove deprecated MealEditor usage - Replace with pure functions
 import { MealEditor } from '~/legacy/utils/data/mealEditor'
+import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 
 export type MealEditViewProps = {
   meal: Meal
@@ -63,6 +64,7 @@ export function MealEditView(props: MealEditViewProps) {
 export function MealEditViewHeader(props: {
   onUpdateMeal: (meal: Meal) => void
 }) {
+  const { show: showConfirmModal } = useConfirmModalContext()
   const { meal } = useMealContext()
   const acceptedClipboardSchema = mealSchema
     .or(itemGroupSchema)
@@ -102,28 +104,24 @@ export function MealEditViewHeader(props: {
 
   const onClearItems = (e: MouseEvent) => {
     e.preventDefault()
-    // This logic is not duplicated with RecipeEditView, so keep it here
-    import('~/sections/common/context/ConfirmModalContext').then(({ useConfirmModalContext }) => {
-      const { show: showConfirmModal } = useConfirmModalContext()
-      showConfirmModal({
-        title: 'Limpar itens',
-        body: 'Tem certeza que deseja limpar os itens?',
-        actions: [
-          { text: 'Cancelar', onClick: () => undefined },
-          {
-            text: 'Excluir todos os itens',
-            primary: true,
-            onClick: () => {
-              const meal_ = meal()
-              if (meal_ === null) {
-                throw new Error('meal_ is null!')
-              }
-              const newMeal = new MealEditor(meal_).clearGroups().finish()
-              props.onUpdateMeal(newMeal)
-            },
+    showConfirmModal({
+      title: 'Limpar itens',
+      body: 'Tem certeza que deseja limpar os itens?',
+      actions: [
+        { text: 'Cancelar', onClick: () => undefined },
+        {
+          text: 'Excluir todos os itens',
+          primary: true,
+          onClick: () => {
+            const meal_ = meal()
+            if (meal_ === null) {
+              throw new Error('meal_ is null!')
+            }
+            const newMeal = new MealEditor(meal_).clearGroups().finish()
+            props.onUpdateMeal(newMeal)
           },
-        ],
-      })
+        },
+      ],
     })
   }
 

--- a/src/sections/recipe/components/RecipeEditView.tsx
+++ b/src/sections/recipe/components/RecipeEditView.tsx
@@ -70,6 +70,8 @@ export default function RecipeEditView(props: RecipeEditViewProps) {
 export function RecipeEditHeader(props: {
   onUpdateRecipe: (Recipe: Recipe) => void
 }) {
+  const { show: showConfirmModal } = useConfirmModalContext()
+
   const acceptedClipboardSchema = mealSchema
     .or(itemGroupSchema)
     .or(itemSchema)
@@ -101,23 +103,20 @@ export function RecipeEditHeader(props: {
 
   const onClearItems = (e: MouseEvent) => {
     e.preventDefault()
-    import('~/sections/common/context/ConfirmModalContext').then(({ useConfirmModalContext }) => {
-      const { show: showConfirmModal } = useConfirmModalContext()
-      showConfirmModal({
-        title: 'Limpar itens',
-        body: 'Tem certeza que deseja limpar os itens?',
-        actions: [
-          { text: 'Cancelar', onClick: () => undefined },
-          {
-            text: 'Excluir todos os itens',
-            primary: true,
-            onClick: () => {
-              const newRecipe = new RecipeEditor(recipe()).clearItems().finish()
-              props.onUpdateRecipe(newRecipe)
-            },
+    showConfirmModal({
+      title: 'Limpar itens',
+      body: 'Tem certeza que deseja limpar os itens?',
+      actions: [
+        { text: 'Cancelar', onClick: () => undefined },
+        {
+          text: 'Excluir todos os itens',
+          primary: true,
+          onClick: () => {
+            const newRecipe = new RecipeEditor(recipe()).clearItems().finish()
+            props.onUpdateRecipe(newRecipe)
           },
-        ],
-      })
+        },
+      ],
     })
   }
 

--- a/src/shared/error/isClipboardNotAllowedError.ts
+++ b/src/shared/error/isClipboardNotAllowedError.ts
@@ -1,0 +1,7 @@
+// Utility to check if an error is a NotAllowedError DOMException
+export function isClipboardNotAllowedError(error: unknown): boolean {
+  return (
+    error instanceof DOMException &&
+    error.name === 'NotAllowedError'
+  )
+}

--- a/src/shared/error/isClipboardNotAllowedError.ts
+++ b/src/shared/error/isClipboardNotAllowedError.ts
@@ -1,7 +1,0 @@
-// Utility to check if an error is a NotAllowedError DOMException
-export function isClipboardNotAllowedError(error: unknown): boolean {
-  return (
-    error instanceof DOMException &&
-    error.name === 'NotAllowedError'
-  )
-}


### PR DESCRIPTION
Refactor clipboard actions in ItemGroupListView and ItemListView to utilize the useClipboard hook, streamlining the copy functionality and improving error handling.

Closes #472 