### PR TITLE
Fix ApexCharts locale configuration for pt-BR

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.271.3+issue.631",
+  "version": "v0.11.0-dev.0+issue.628",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/src/sections/common/components/charts/TestChart.tsx
+++ b/src/sections/common/components/charts/TestChart.tsx
@@ -1,17 +1,7 @@
 import { SolidApexCharts } from 'solid-apexcharts'
 import { createSignal } from 'solid-js'
+import ptBrLocale from '~/assets/locales/apex/pt-br.json'
 
-// TODO: apexcharts.esm.js?v=55c99a60:5 Uncaught (in promise) Error: Wrong locale name provided. Please make sure you set the correct locale name in options
-// at t.value (apexcharts.esm.js?v=55c99a60:5:181477)
-// at t.value (apexcharts.esm.js?v=55c99a60:9:46335)
-// at apexcharts.esm.js?v=55c99a60:9:21999
-// at new Promise (<anonymous>)
-// at t.value (apexcharts.esm.js?v=55c99a60:9:21788)
-// at init (dev.jsx:30:11)
-// at dev.jsx:33:5
-// at untrack (chunk-5AFA2RXD.js?v=55c99a60:473:12)
-// at Object.fn (chunk-5AFA2RXD.js?v=55c99a60:498:22)
-// at runComputation (chunk-5AFA2RXD.js?v=55c99a60:740:22)
 export function TestChart() {
   const [options] = createSignal<ApexCharts.ApexOptions>({
     theme: {
@@ -19,7 +9,7 @@ export function TestChart() {
     },
     chart: {
       id: 'solidchart-example',
-      locales: [],
+      locales: [ptBrLocale],
       defaultLocale: 'pt-br',
       background: '#1a202c',
       toolbar: {


### PR DESCRIPTION
Correct the locale configuration for ApexCharts to properly use the Brazilian Portuguese locale. Update the versioning to reflect the changes.