### PR TITLE
Refactor type guards and template handling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,6 @@
   "editor.detectIndentation": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "always",
-    "source.sortImports": "explicit"
   },
   "eslint.validate": [
     "typescript",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,6 +4,7 @@ import pluginTs from '@typescript-eslint/eslint-plugin'
 import parserTs from '@typescript-eslint/parser'
 import pluginA11y from 'eslint-plugin-jsx-a11y'
 import pluginPrettier from 'eslint-plugin-prettier'
+import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import pluginSolid from 'eslint-plugin-solid'
 import globals from 'globals'
 
@@ -32,6 +33,7 @@ export default [
       solid: pluginSolid,
       prettier: pluginPrettier,
       'jsx-a11y': pluginA11y,
+      simpleImportSort
     },
     rules: {
       ...js.configs.recommended.rules,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.281.2+issue.175",
+  "version": "v0.11.0-dev.282.3+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.280.1+issue.175",
+  "version": "v0.11.0-dev.281.2+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",
@@ -53,6 +53,7 @@
     "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
     "eslint-plugin-prettier": "5.0.0-alpha.2",
     "eslint-plugin-promise": "^6.0.0",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-solid": "^0.14.5",
     "eslint-plugin-unicorn": "^59.0.1",
     "globals": "^16.2.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.282.3+issue.175",
+  "version": "v0.11.0-dev.283.4+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.284.5+issue.175",
+  "version": "v0.11.0-dev.285.6+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.283.4+issue.175",
+  "version": "v0.11.0-dev.284.5+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.285.6+issue.175",
+  "version": "v0.11.0-dev.286.7+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.274.1+issue.630",
+  "version": "v0.11.0-dev.280.1+issue.175",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       eslint-plugin-promise:
         specifier: ^6.0.0
         version: 6.6.0(eslint@8.57.1)
+      eslint-plugin-simple-import-sort:
+        specifier: ^12.1.1
+        version: 12.1.1(eslint@8.57.1)
       eslint-plugin-solid:
         specifier: ^0.14.5
         version: 0.14.5(eslint@8.57.1)(typescript@4.9.5)
@@ -2932,6 +2935,11 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
+
+  eslint-plugin-simple-import-sort@12.1.1:
+    resolution: {integrity: sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-plugin-solid@0.14.5:
     resolution: {integrity: sha512-nfuYK09ah5aJG/oEN6P1qziy1zLgW4PDWe75VNPi4CEFYk1x2AEqwFeQfEPR7gNn0F2jOeqKhx2E+5oNCOBYWQ==}
@@ -8506,6 +8514,10 @@ snapshots:
       eslint-config-prettier: 8.10.0(eslint@8.57.1)
 
   eslint-plugin-promise@6.6.0(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
+  eslint-plugin-simple-import-sort@12.1.1(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 

--- a/src/modules/diet/item-group/domain/itemGroup.ts
+++ b/src/modules/diet/item-group/domain/itemGroup.ts
@@ -29,10 +29,30 @@ export const recipedItemGroupSchema = z.object({
   __type: z.literal('ItemGroup').default('ItemGroup'),
 })
 
-export const itemGroupSchema = z.discriminatedUnion('type', [
+export const itemGroupSchema = z.union([
   simpleItemGroupSchema,
   recipedItemGroupSchema,
 ])
+
+/**
+ * Type guard for SimpleItemGroup.
+ * @param group - The ItemGroup to check
+ * @returns True if group is SimpleItemGroup
+ */
+export function isSimpleItemGroup(group: ItemGroup): group is SimpleItemGroup {
+  return group.type === 'simple'
+}
+
+/**
+ * Type guard for RecipedItemGroup.
+ * @param group - The ItemGroup to check
+ * @returns True if group is RecipedItemGroup
+ */
+export function isRecipedItemGroup(
+  group: ItemGroup,
+): group is RecipedItemGroup {
+  return group.type === 'recipe'
+}
 
 // Use output type for strict clipboard unions
 export type SimpleItemGroup = Readonly<z.output<typeof simpleItemGroupSchema>>
@@ -42,7 +62,7 @@ export type ItemGroup = Readonly<z.output<typeof itemGroupSchema>>
 export function isSimpleSingleGroup(
   group: ItemGroup,
 ): group is SimpleItemGroup {
-  return group.type === 'simple' && group.items.length === 1
+  return isSimpleItemGroup(group) && group.items.length === 1
 }
 
 /**

--- a/src/modules/diet/template-item/domain/templateItem.ts
+++ b/src/modules/diet/template-item/domain/templateItem.ts
@@ -2,9 +2,28 @@ import { z } from 'zod'
 import { itemSchema } from '~/modules/diet/item/domain/item'
 import { recipeItemSchema } from '~/modules/diet/recipe-item/domain/recipeItem'
 
-export const templateItemSchema = z.discriminatedUnion('__type', [
-  itemSchema,
-  recipeItemSchema,
-])
+export const templateItemSchema = z.union([itemSchema, recipeItemSchema])
 
 export type TemplateItem = Readonly<z.infer<typeof templateItemSchema>>
+
+/**
+ * Type guard for TemplateItem (Item).
+ * @param t - The TemplateItem to check
+ * @returns True if TemplateItem is Item
+ */
+export function isTemplateItemFood(
+  t: TemplateItem,
+): t is Readonly<z.output<typeof itemSchema>> {
+  return t.__type === 'Item'
+}
+
+/**
+ * Type guard for TemplateItem (RecipeItem).
+ * @param t - The TemplateItem to check
+ * @returns True if TemplateItem is RecipeItem
+ */
+export function isTemplateItemRecipe(
+  t: TemplateItem,
+): t is Readonly<z.output<typeof recipeItemSchema>> {
+  return t.__type === 'RecipeItem'
+}

--- a/src/modules/diet/template-item/domain/templateItem.ts
+++ b/src/modules/diet/template-item/domain/templateItem.ts
@@ -4,26 +4,24 @@ import { recipeItemSchema } from '~/modules/diet/recipe-item/domain/recipeItem'
 
 export const templateItemSchema = z.union([itemSchema, recipeItemSchema])
 
-export type TemplateItem = Readonly<z.infer<typeof templateItemSchema>>
+export type FoodTemplateItem = Readonly<z.output<typeof itemSchema>>
+export type RecipeTemplateItem = Readonly<z.output<typeof recipeItemSchema>>
+export type TemplateItem = FoodTemplateItem | RecipeTemplateItem
 
 /**
- * Type guard for TemplateItem (Item).
+ * Checks if a TemplateItem is a FoodTemplateItem (Item).
  * @param t - The TemplateItem to check
- * @returns True if TemplateItem is Item
+ * @returns True if t is a FoodTemplateItem
  */
-export function isTemplateItemFood(
-  t: TemplateItem,
-): t is Readonly<z.output<typeof itemSchema>> {
+export function isTemplateItemFood(t: TemplateItem): t is FoodTemplateItem {
   return t.__type === 'Item'
 }
 
 /**
- * Type guard for TemplateItem (RecipeItem).
+ * Checks if a TemplateItem is a RecipeTemplateItem (RecipeItem).
  * @param t - The TemplateItem to check
- * @returns True if TemplateItem is RecipeItem
+ * @returns True if t is a RecipeTemplateItem
  */
-export function isTemplateItemRecipe(
-  t: TemplateItem,
-): t is Readonly<z.output<typeof recipeItemSchema>> {
+export function isTemplateItemRecipe(t: TemplateItem): t is RecipeTemplateItem {
   return t.__type === 'RecipeItem'
 }

--- a/src/modules/diet/template/application/createGroupFromTemplate.ts
+++ b/src/modules/diet/template/application/createGroupFromTemplate.ts
@@ -3,12 +3,14 @@ import {
   createSimpleItemGroup,
   type ItemGroup,
 } from '~/modules/diet/item-group/domain/itemGroup'
-import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
 import {
   isTemplateItemFood,
   type TemplateItem,
 } from '~/modules/diet/template-item/domain/templateItem'
-import { type Template } from '~/modules/diet/template/domain/template'
+import {
+  isTemplateRecipe,
+  type Template,
+} from '~/modules/diet/template/domain/template'
 
 /**
  * Creates an ItemGroup from a Template and TemplateItem, returning group, operation and templateType.
@@ -30,13 +32,18 @@ export function createGroupFromTemplate(
       templateType: 'Item',
     }
   }
-  return {
-    newGroup: createRecipedItemGroup({
-      name: item.name,
-      recipe: (template as Recipe).id,
-      items: [...(template as Recipe).items],
-    }),
-    operation: 'addRecipeItem',
-    templateType: 'Recipe',
+
+  if (isTemplateRecipe(template)) {
+    return {
+      newGroup: createRecipedItemGroup({
+        name: item.name,
+        recipe: template.id,
+        items: [...template.items],
+      }),
+      operation: 'addRecipeItem',
+      templateType: 'Recipe',
+    }
   }
+
+  throw new Error('Template is not a Recipe')
 }

--- a/src/modules/diet/template/application/createGroupFromTemplate.ts
+++ b/src/modules/diet/template/application/createGroupFromTemplate.ts
@@ -1,0 +1,42 @@
+import {
+  createRecipedItemGroup,
+  createSimpleItemGroup,
+  type ItemGroup,
+} from '~/modules/diet/item-group/domain/itemGroup'
+import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
+import {
+  isTemplateItemFood,
+  type TemplateItem,
+} from '~/modules/diet/template-item/domain/templateItem'
+import { type Template } from '~/modules/diet/template/domain/template'
+
+/**
+ * Creates an ItemGroup from a Template and TemplateItem, returning group, operation and templateType.
+ * @param template - The Template (food or recipe)
+ * @param item - The TemplateItem (Item or RecipeItem)
+ * @returns Object with newGroup, operation, templateType
+ */
+export function createGroupFromTemplate(
+  template: Template,
+  item: TemplateItem,
+): { newGroup: ItemGroup; operation: string; templateType: string } {
+  if (isTemplateItemFood(item)) {
+    return {
+      newGroup: createSimpleItemGroup({
+        name: item.name,
+        items: [item],
+      }),
+      operation: 'addSimpleItem',
+      templateType: 'Item',
+    }
+  }
+  return {
+    newGroup: createRecipedItemGroup({
+      name: item.name,
+      recipe: (template as Recipe).id,
+      items: [...(template as Recipe).items],
+    }),
+    operation: 'addRecipeItem',
+    templateType: 'Recipe',
+  }
+}

--- a/src/modules/diet/template/application/templateToItem.ts
+++ b/src/modules/diet/template/application/templateToItem.ts
@@ -1,0 +1,30 @@
+import { calcRecipeMacros } from '~/legacy/utils/macroMath'
+import { type Item } from '~/modules/diet/item/domain/item'
+import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
+import { type RecipeItem } from '~/modules/diet/recipe-item/domain/recipeItem'
+import {
+  type Template,
+  isTemplateFood,
+} from '~/modules/diet/template/domain/template'
+
+/**
+ * Converts a Template (FoodTemplate or RecipeTemplate) to an Item or RecipeItem for use in item groups.
+ * @param template - The Template to convert
+ * @returns The corresponding Item or RecipeItem
+ */
+export function templateToItem(template: Template): Item | RecipeItem {
+  if (isTemplateFood(template)) {
+    return {
+      reference: template.id,
+      name: template.name,
+      macros: template.macros,
+      __type: 'Item',
+    } as Item
+  }
+  return {
+    reference: template.id,
+    name: template.name,
+    macros: calcRecipeMacros(template as Recipe),
+    __type: 'RecipeItem',
+  } as RecipeItem
+}

--- a/src/modules/diet/template/application/templateToItem.ts
+++ b/src/modules/diet/template/application/templateToItem.ts
@@ -1,7 +1,7 @@
 import { calcRecipeMacros } from '~/legacy/utils/macroMath'
 import { type Item } from '~/modules/diet/item/domain/item'
-import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
 import { type RecipeItem } from '~/modules/diet/recipe-item/domain/recipeItem'
+import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
 import {
   type Template,
   isTemplateFood,

--- a/src/modules/diet/template/domain/template.ts
+++ b/src/modules/diet/template/domain/template.ts
@@ -2,17 +2,26 @@ import { z } from 'zod'
 import { foodSchema } from '~/modules/diet/food/domain/food'
 import { recipeSchema } from '~/modules/diet/recipe/domain/recipe'
 
-export const TemplateSchema = z.discriminatedUnion('__type', [
-  z
-    .object({
-      __type: z.literal('food'),
-    })
-    .merge(foodSchema),
-  z
-    .object({
-      __type: z.literal('recipe'),
-    })
-    .merge(recipeSchema),
-])
+export const templateSchema = z.union([foodSchema, recipeSchema])
 
-export type Template = Readonly<z.infer<typeof TemplateSchema>>
+export type FoodTemplate = Readonly<z.output<typeof foodSchema>>
+export type RecipeTemplate = Readonly<z.output<typeof recipeSchema>>
+export type Template = FoodTemplate | RecipeTemplate
+
+/**
+ * Type guard for Template (food).
+ * @param t - The Template to check
+ * @returns True if Template is food
+ */
+export function isTemplateFood(t: Template): t is FoodTemplate {
+  return t.__type === 'Food'
+}
+
+/**
+ * Type guard for Template (recipe).
+ * @param t - The Template to check
+ * @returns True if Template is recipe
+ */
+export function isTemplateRecipe(t: Template): t is RecipeTemplate {
+  return t.__type === 'Recipe'
+}

--- a/src/sections/food-item/components/ItemEditModal.tsx
+++ b/src/sections/food-item/components/ItemEditModal.tsx
@@ -25,12 +25,21 @@ import {
 } from 'solid-js'
 import { showError } from '~/modules/toast/application/toastManager'
 
+/**
+ * Modal for editing a TemplateItem.
+ *
+ * @param targetName - Name of the target (meal/group/recipe)
+ * @param targetNameColor - Optional color for the target name
+ * @param item - Accessor for the TemplateItem being edited
+ * @param macroOverflow - Macro overflow context
+ * @param onApply - Called when user applies changes
+ * @param onCancel - Called when user cancels
+ * @param onDelete - Called when user deletes the item
+ */
 export type ItemEditModalProps = {
   targetName: string
   targetNameColor?: string
-  item: Accessor<
-    Partial<TemplateItem> & Pick<TemplateItem, 'name' | 'reference' | 'macros'>
-  >
+  item: Accessor<TemplateItem>
   macroOverflow: () => {
     enable: boolean
     originalItem?: TemplateItem | undefined
@@ -58,9 +67,9 @@ export const ItemEditModal = (_props: ItemEditModalProps) => {
   createEffect(() => {
     setItem({
       ...props.item(),
-      __type: props.item().__type ?? 'Item',
-      id: props.item().id ?? generateId(),
-      quantity: props.item().quantity ?? 0,
+      __type: props.item().__type,
+      id: props.item().id,
+      quantity: props.item().quantity,
       name: props.item().name,
       reference: props.item().reference,
       macros: props.item().macros,

--- a/src/sections/food-item/components/ItemEditModal.tsx
+++ b/src/sections/food-item/components/ItemEditModal.tsx
@@ -1,4 +1,3 @@
-import { generateId } from '~/legacy/utils/idUtils'
 import { type Item } from '~/modules/diet/item/domain/item'
 import { type TemplateItem } from '~/modules/diet/template-item/domain/templateItem'
 import { FloatInput } from '~/sections/common/components/FloatInput'
@@ -54,27 +53,8 @@ export const ItemEditModal = (_props: ItemEditModalProps) => {
   const { setVisible } = useModalContext()
   const { show: showConfirmModal } = useConfirmModalContext()
 
-  // TODO:   Better initial state for item on ItemEditModal
-  const fallbackItem: TemplateItem = {
-    __type: 'Item',
-    id: generateId(),
-    name: '',
-    quantity: 0,
-    reference: 0, // assuming number, adjust if needed
-    macros: { carbs: 0, protein: 0, fat: 0 },
-  }
-  const [item, setItem] = createSignal<TemplateItem>(fallbackItem)
-  createEffect(() => {
-    setItem({
-      ...props.item(),
-      __type: props.item().__type,
-      id: props.item().id,
-      quantity: props.item().quantity,
-      name: props.item().name,
-      reference: props.item().reference,
-      macros: props.item().macros,
-    })
-  })
+  const [item, setItem] = createSignal(untrack(() => props.item()))
+  createEffect(() => setItem(props.item()))
 
   const canApply = () => item().quantity > 0
 

--- a/src/sections/food-item/components/ItemView.tsx
+++ b/src/sections/food-item/components/ItemView.tsx
@@ -1,6 +1,10 @@
 import { calcItemCalories, calcItemMacros } from '~/legacy/utils/macroMath'
 import { type MacroNutrients } from '~/modules/diet/macro-nutrients/domain/macroNutrients'
-import { type TemplateItem } from '~/modules/diet/template-item/domain/templateItem'
+import {
+  isTemplateItemFood,
+  isTemplateItemRecipe,
+  type TemplateItem,
+} from '~/modules/diet/template-item/domain/templateItem'
 import { type Template } from '~/modules/diet/template/domain/template'
 import {
   isFoodFavorite,
@@ -82,7 +86,7 @@ export function ItemName() {
     console.debug('[ItemName] item changed, fetching API:', item())
 
     const itemValue = item()
-    if (itemValue.__type === 'RecipeItem') {
+    if (isTemplateItemRecipe(itemValue)) {
       recipeRepository
         .fetchRecipeById(itemValue.reference)
         .then(setTemplate)
@@ -94,7 +98,7 @@ export function ItemName() {
           })
           setTemplate(null)
         })
-    } else {
+    } else if (isTemplateItemFood(itemValue)) {
       fetchFoodById(itemValue.reference)
         .then(setTemplate)
         .catch((err) => {
@@ -109,9 +113,9 @@ export function ItemName() {
   })
 
   const templateNameColor = () => {
-    if (item().__type === 'Item') {
+    if (isTemplateItemFood(item())) {
       return 'text-white'
-    } else if (item().__type === 'RecipeItem') {
+    } else if (isTemplateItemRecipe(item())) {
       return 'text-blue-500'
     } else {
       handleValidationError(

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -4,6 +4,8 @@ import {
   type ItemGroup,
   type RecipedItemGroup,
   getItemGroupQuantity,
+  isRecipedItemGroup,
+  isSimpleItemGroup,
   isSimpleSingleGroup,
   itemGroupSchema,
 } from '~/modules/diet/item-group/domain/itemGroup'
@@ -12,7 +14,10 @@ import {
   type Recipe,
   createNewRecipe,
 } from '~/modules/diet/recipe/domain/recipe'
-import { type TemplateItem } from '~/modules/diet/template-item/domain/templateItem'
+import {
+  type TemplateItem,
+  isTemplateItemRecipe,
+} from '~/modules/diet/template-item/domain/templateItem'
 import { RecipeIcon } from '~/sections/common/components/icons/RecipeIcon'
 import { Modal } from '~/sections/common/components/Modal'
 import { ExternalItemEditModal } from '~/sections/food-item/components/ExternalItemEditModal'
@@ -187,7 +192,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
 
   createEffect(() => {
     const group_ = group()
-    if (group_.type !== 'recipe') {
+    if (!isRecipedItemGroup(group_)) {
       setRecipeSignal({ loading: false, errored: false, data: null })
       return
     }
@@ -207,7 +212,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
 
   createEffect(() => {
     const group_ = group()
-    const groupHasRecipe = group_.type === 'recipe'
+    const groupHasRecipe = isRecipedItemGroup(group_)
     console.debug('Group changed:', group())
 
     if (groupHasRecipe) {
@@ -239,7 +244,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
     const group_ = group()
     // TODO:   Allow user to edit recipe.
     // TODO:   Allow user to edit recipe inside a group.
-    if (item.__type === 'RecipeItem') {
+    if (isTemplateItemRecipe(item)) {
       showError(
         'Ainda não é possível editar receitas! Funcionalidade em desenvolvimento',
       )
@@ -459,7 +464,7 @@ function Body(props: {
   const { group, setGroup } = useItemGroupEditContext()
   const recipedGroup = createMemo(() => {
     const currentGroup = group()
-    return currentGroup.type === 'recipe' ? currentGroup : null
+    return isRecipedItemGroup(currentGroup) ? currentGroup : null
   })
 
   // Use output types for strict type-safety
@@ -542,7 +547,7 @@ function Body(props: {
                   )}
                 </Show>
 
-                <Show when={group().type === 'simple'}>
+                <Show when={isSimpleItemGroup(group())}>
                   {(_) => (
                     <>
                       <button
@@ -587,7 +592,7 @@ function Body(props: {
                 <Show
                   when={(() => {
                     const group_ = group()
-                    return group_.type === 'recipe' && group_
+                    return isRecipedItemGroup(group_) && group_
                   })()}
                 >
                   {(group) => (
@@ -655,7 +660,6 @@ function Body(props: {
                       </Show>
 
                       <Show when={props.recipe() === null}>
-                        {/* Direct JSX child, not a function */}
                         <>Receita não encontrada</>
                       </Show>
                     </>
@@ -671,15 +675,12 @@ function Body(props: {
             //   className="mt-4"
             onItemClick={(item) => {
               // TODO:   Allow user to edit recipe
-              if (item.__type === 'RecipeItem') {
+              if (isTemplateItemRecipe(item)) {
                 showError(
                   'Ainda não é possível editar receitas! Funcionalidade em desenvolvimento',
                 )
                 return
               }
-              // if (group?.type === 'recipe') {
-              //   recipeEditModalRef.current?.showModal()
-              // } else {
 
               // TODO: Support editing complex recipes
               if (isRecipeTooComplex(props.recipe())) {

--- a/src/sections/item-group/components/ItemGroupView.tsx
+++ b/src/sections/item-group/components/ItemGroupView.tsx
@@ -12,6 +12,8 @@ import {
   SimpleItemGroup,
   getItemGroupQuantity,
   isRecipedGroupUpToDate,
+  isRecipedItemGroup,
+  isSimpleItemGroup,
   isSimpleSingleGroup,
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
@@ -63,7 +65,7 @@ export function ItemGroupName(props: { group: Accessor<ItemGroup> }) {
   createEffect(() => {
     console.debug('[ItemGroupName] item changed, fetching API:', props.group)
     const group = props.group()
-    if (group.type === 'recipe') {
+    if (isRecipedItemGroup(group)) {
       recipeRepository
         .fetchRecipeById(group.recipe)
         .then((foundRecipe) => {
@@ -114,23 +116,22 @@ export function ItemGroupName(props: { group: Accessor<ItemGroup> }) {
       }
     }
 
-    switch (group_.type) {
-      case 'simple':
-        return handleSimple(group_ as SimpleItemGroup)
-      case 'recipe':
-        if (recipe_.data !== null) {
-          return handleRecipe(group_ as RecipedItemGroup, recipe_.data)
-        } else {
-          return 'text-red-400'
-        }
-      default:
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        handleValidationError(new Error(`Unknown ItemGroup: ${group_}`), {
-          component: 'ItemGroupView::ItemGroupName',
-          operation: 'nameColor',
-          additionalData: { group: group_ },
-        })
+    if (isSimpleItemGroup(group_)) {
+      return handleSimple(group_)
+    } else if (isRecipedItemGroup(group_)) {
+      if (recipe_.data !== null) {
+        return handleRecipe(group_, recipe_.data)
+      } else {
         return 'text-red-400'
+      }
+    } else {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      handleValidationError(new Error(`Unknown ItemGroup: ${group_}`), {
+        component: 'ItemGroupView::ItemGroupName',
+        operation: 'nameColor',
+        additionalData: { group: group_ },
+      })
+      return 'text-red-400'
     }
   }
 

--- a/src/sections/recipe/components/RecipeEditModal.tsx
+++ b/src/sections/recipe/components/RecipeEditModal.tsx
@@ -9,6 +9,10 @@ import {
   removeItemFromRecipe,
   updateItemInRecipe,
 } from '~/modules/diet/recipe/domain/recipeOperations'
+import {
+  isTemplateItemFood,
+  isTemplateItemRecipe,
+} from '~/modules/diet/template-item/domain/templateItem'
 import { showError } from '~/modules/toast/application/toastManager'
 import { Modal } from '~/sections/common/components/Modal'
 import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
@@ -99,7 +103,7 @@ export function RecipeEditModal(props: RecipeEditModalProps) {
         targetName={recipe().name}
         onApply={(item) => {
           // Only handle regular Items, not RecipeItems
-          if (item.__type !== 'Item') {
+          if (!isTemplateItemFood(item)) {
             console.warn('Cannot edit RecipeItems in recipe')
             return
           }
@@ -155,7 +159,7 @@ export function RecipeEditModal(props: RecipeEditModalProps) {
                 }}
                 onEditItem={(item) => {
                   // TODO:   Allow user to edit recipe.
-                  if (item.__type === 'RecipeItem') {
+                  if (isTemplateItemRecipe(item)) {
                     showError(
                       'Ainda não é possível editar receitas dentro de receitas! Funcionalidade em desenvolvimento',
                     )

--- a/src/sections/search/components/ExternalTemplateToItemGroupModal.tsx
+++ b/src/sections/search/components/ExternalTemplateToItemGroupModal.tsx
@@ -1,20 +1,24 @@
 import { type Accessor, type Setter } from 'solid-js'
-import { showError } from '~/modules/toast/application/toastManager'
-import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
-import { ItemEditModal } from '~/sections/food-item/components/ItemEditModal'
+import { calcRecipeMacros } from '~/legacy/utils/macroMath'
 import {
   type ItemGroup,
   type RecipedItemGroup,
   type SimpleItemGroup,
-  createSimpleItemGroup,
   createRecipedItemGroup,
+  createSimpleItemGroup,
 } from '~/modules/diet/item-group/domain/itemGroup'
-import { type Template } from '~/modules/diet/template/domain/template'
+import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
 import { type TemplateItem } from '~/modules/diet/template-item/domain/templateItem'
+import {
+  type Template,
+  isTemplateFood,
+  isTemplateRecipe,
+} from '~/modules/diet/template/domain/template'
+import { showError } from '~/modules/toast/application/toastManager'
 import { ModalContextProvider } from '~/sections/common/context/ModalContext'
-import { formatError } from '~/shared/formatError'
+import { ItemEditModal } from '~/sections/food-item/components/ItemEditModal'
 import { handleApiError } from '~/shared/error/errorHandler'
-import { calcRecipeMacros } from '~/legacy/utils/macroMath'
+import { formatError } from '~/shared/formatError'
 
 export type ExternalTemplateToItemGroupModalProps = {
   visible: Accessor<boolean>
@@ -36,15 +40,14 @@ export function ExternalTemplateToItemGroupModal(
         targetName={props.targetName}
         item={() => {
           const template = props.selectedTemplate()
-          const macros =
-            template.__type === 'Food'
-              ? template.macros
-              : calcRecipeMacros(template)
+          const macros = isTemplateFood(template)
+            ? template.macros
+            : calcRecipeMacros(template)
           return {
             reference: template.id,
             name: template.name,
             macros,
-            __type: template.__type === 'Food' ? 'Item' : 'RecipeItem', // TODO:   Refactor conversion from template type to group/item types
+            __type: isTemplateFood(template) ? 'Item' : 'RecipeItem', // TODO:   Refactor conversion from template type to group/item types
           }
         }}
         macroOverflow={() => ({

--- a/src/sections/search/components/ExternalTemplateToItemGroupModal.tsx
+++ b/src/sections/search/components/ExternalTemplateToItemGroupModal.tsx
@@ -1,5 +1,4 @@
 import { type Accessor, type Setter } from 'solid-js'
-import { calcRecipeMacros } from '~/legacy/utils/macroMath'
 import {
   type ItemGroup,
   type RecipedItemGroup,
@@ -9,16 +8,13 @@ import {
 } from '~/modules/diet/item-group/domain/itemGroup'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
 import { type TemplateItem } from '~/modules/diet/template-item/domain/templateItem'
-import {
-  type Template,
-  isTemplateFood,
-  isTemplateRecipe,
-} from '~/modules/diet/template/domain/template'
 import { showError } from '~/modules/toast/application/toastManager'
 import { ModalContextProvider } from '~/sections/common/context/ModalContext'
 import { ItemEditModal } from '~/sections/food-item/components/ItemEditModal'
 import { handleApiError } from '~/shared/error/errorHandler'
 import { formatError } from '~/shared/formatError'
+import { templateToItem } from '~/modules/diet/template/application/templateToItem'
+import { type Template } from '~/modules/diet/template/domain/template'
 
 export type ExternalTemplateToItemGroupModalProps = {
   visible: Accessor<boolean>
@@ -38,23 +34,11 @@ export function ExternalTemplateToItemGroupModal(
     <ModalContextProvider visible={props.visible} setVisible={props.setVisible}>
       <ItemEditModal
         targetName={props.targetName}
-        item={() => {
-          const template = props.selectedTemplate()
-          const macros = isTemplateFood(template)
-            ? template.macros
-            : calcRecipeMacros(template)
-          return {
-            reference: template.id,
-            name: template.name,
-            macros,
-            __type: isTemplateFood(template) ? 'Item' : 'RecipeItem', // TODO:   Refactor conversion from template type to group/item types
-          }
-        }}
+        item={() => templateToItem(props.selectedTemplate())}
         macroOverflow={() => ({
           enable: true,
         })}
         onApply={(item) => {
-          // TODO:   Refactor conversion from template type to group/item types
           if (item.__type === 'Item') {
             const newGroup: SimpleItemGroup = createSimpleItemGroup({
               name: item.name,

--- a/src/sections/search/components/TemplateSearchResults.tsx
+++ b/src/sections/search/components/TemplateSearchResults.tsx
@@ -3,7 +3,11 @@ import { calcRecipeMacros } from '~/legacy/utils/macroMath'
 import { type Food } from '~/modules/diet/food/domain/food'
 import { createItem } from '~/modules/diet/item/domain/item'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
-import { type Template } from '~/modules/diet/template/domain/template'
+import {
+  type Template,
+  isTemplateFood,
+  isTemplateRecipe,
+} from '~/modules/diet/template/domain/template'
 import { Alert } from '~/sections/common/components/Alert'
 import { HeaderWithActions } from '~/sections/common/components/HeaderWithActions'
 import {
@@ -43,13 +47,12 @@ export function TemplateSearchResults(props: {
                     ...createItem({
                       name: template.name,
                       quantity: 100,
-                      macros:
-                        template.__type === 'Food'
-                          ? (template as Food).macros
-                          : calcRecipeMacros(template as Recipe),
+                      macros: isTemplateFood(template)
+                        ? (template as Food).macros
+                        : calcRecipeMacros(template as Recipe),
                       reference: template.id,
                     }),
-                    __type: template.__type === 'Food' ? 'Item' : 'RecipeItem', // TODO:   Refactor conversion from template type to group/item types
+                    __type: isTemplateFood(template) ? 'Item' : 'RecipeItem', // TODO:   Refactor conversion from template type to group/item types
                   })}
                   class="mt-1"
                   macroOverflow={() => ({


### PR DESCRIPTION
Enhance type safety by enforcing type guard usage for discriminated unions, centralizing template-to-item conversion, and refactoring group creation logic. Update documentation and clean up modal logic for improved clarity and maintainability.

Closes #175
Closes #369