### PR TITLE
Refactor day-diet and item-group components for improved UX

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,6 @@
+---
+applyTo: "**"
+---
 # Copilot Instructions (short version)
 During this session, always wait until the end of the execution of any requested command or process, even if it takes several minutes, before responding. For every command, redirect both stdout and stderr to `/tmp/copilot-terminal` using `| tee /tmp/copilot-terminal 2>&1`. After the main command finishes, check `cat /tmp/copilot-terminal`. Never repeat the main command. Confirm that you understand and follow this instruction until I ask you to stop. Never combine commands with `&&`, `||` or `;`
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,46 +10,55 @@
     "javascript",
     "javascriptreact"
   ],
+  // "chat.editing.autoAcceptDelay": 100,
+  // "chat.extensionTools.enabled": true,
+  // "chat.commandCenter.enabled": true,
+  // "chat.instructionsFilesLocations": {
+  //   ".github/instructions": true,
+  //   "/Users/vscode/repos/instructions": true
+  // },
+  // "chat.mcp.discovery.enabled": true,
+  // "chat.edits2.enabled": true,
+  // "inlineChat.enableV2": true,
+  // "chat.agent.maxRequests": 200,
+  // "github.copilot.chat.agent.runTasks": true,
+  // "github.copilot.chat.agent.thinkingTool": true,
+  // "github.copilot.chat.languageContext.typescript.enabled": true,
+  // "github.copilot.chat.languageContext.inline.typescript.enabled": true,
+  // "github.copilot.chat.summarizeAgentConversationHistory.enabled": true,
+  // "github.copilot.chat.edits.temporalContext.enabled": true,
+  // "github.copilot.chat.followUps": "always",
+  // "github.copilot.chat.generateTests.codeLens": true,
+  // "github.copilot.chat.search.keywordSuggestions": true,
+  // "github.copilot.chat.terminalChatLocation": "terminal",
+  // "github.copilot.advanced": {
+  //   "useLanguageServer": true,
+  // },
+  // "github.copilot.chat.codeGeneration.useInstructionFiles": true,
   "github.copilot.chat.codeGeneration.instructions": [
     {
       "file": "docs/COPILOT_SHORT_GUIDE.md"
     }
   ],
+  // "github.copilot.chat.testGeneration.instructions": [
+  //   {
+  //     "file": "docs/COPILOT_TESTS_GUIDE.md"
+  //   }
+  // ],
+  // "github.copilot.chat.reviewSelection.enabled": true,
+  // "github.copilot.chat.reviewSelection.instructions": [
+  //   {
+  //     "file": ".copilot-review-instructions.md"
+  //   }
+  // ],
+  // "github.copilot.chat.pullRequestDescriptionGeneration.instructions": [
+  //   {
+  //     "file": ".copilot-pull-request-description-instructions.md"
+  //   }
+  // ],
   "github.copilot.chat.commitMessageGeneration.instructions": [
     {
       "text": " We follow the [Conventional Commits](https://www.conventionalcommits.org/) standard, with an extension for more specific types:\n\n| Type       | When to use                                                        |\n|------------|--------------------------------------------------------------------|\n| `feat`     | New feature or endpoint                                            |\n| `fix`      | Bug fixes                                                         |\n| `refactor` | Internal refactoring without behavior change                      |\n| `style`    | Changes that do not affect behavior (spaces, formatting)           |\n| `docs`     | Documentation changes                                              |\n| `test`     | Adding or modifying tests                                          |\n| `build`    | Changes to the build process (Makefile, Dockerfile, etc)           |\n| `ci`       | Changes to pipelines, GitHub Actions, etc                          |\n| `chore`    | Dependency updates, configs, administrative tasks                  |\n| `revert`   | Reverting a previous commit                                       |\n\n### Example:\n\nfeat(api): add endpoint for user creation\nfix(auth): fix JWT token expiration\nrefactor(service): move retry logic to middleware\nchore(deps): update Go to 1.22\ndocs: update README with build instructions. ALL COMMITS MUST BE IN TECHNICAL ENGLISH, BRIEF BUT DO NOT OMIT ANY MODIFICATION."
     }
-  ],
-  "cSpell.words": [
-    "apexcharts",
-    "camelcase",
-    "CODABAR",
-    "datamax",
-    "datamin",
-    "datepicker",
-    "Datepicker",
-    "dayjs",
-    "DDMM",
-    "flowbite",
-    "Kg",
-    "MAXICODE",
-    "normo",
-    "Normocalórica",
-    "ohlc",
-    "Pastable",
-    "qrbox",
-    "qrcode",
-    "Qrcode",
-    "reciped",
-    "Reciped",
-    "solidchart",
-    "solidjs",
-    "supabase",
-    "unmark",
-    "xaxis",
-    "yaxis",
-    "Yaxis",
-    "zoomin",
-    "zoomout"
   ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,7 +20,7 @@
   // "chat.mcp.discovery.enabled": true,
   // "chat.edits2.enabled": true,
   // "inlineChat.enableV2": true,
-  // "chat.agent.maxRequests": 200,
+  "chat.agent.maxRequests": 200,
   // "github.copilot.chat.agent.runTasks": true,
   // "github.copilot.chat.agent.thinkingTool": true,
   // "github.copilot.chat.languageContext.typescript.enabled": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.318.8+issue.26",
+  "version": "v0.11.0-dev.319.9+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.317.7+issue.26",
+  "version": "v0.11.0-dev.318.8+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.0+issue.26",
+  "version": "v0.11.0-dev.311.1+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.313.3+issue.26",
+  "version": "v0.11.0-dev.314.4+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.320.10+issue.26",
+  "version": "v0.11.0-dev.321.11+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.316.6+issue.26",
+  "version": "v0.11.0-dev.317.7+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-rc.307",
+  "version": "v0.11.0-dev.0+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.323.13+issue.26",
+  "version": "v0.11.0-dev.324.14+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.321.11+issue.26",
+  "version": "v0.11.0-dev.322.12+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.322.12+issue.26",
+  "version": "v0.11.0-dev.323.13+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.315.5+issue.26",
+  "version": "v0.11.0-dev.316.6+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.311.1+issue.26",
+  "version": "v0.11.0-dev.312.2+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.319.9+issue.26",
+  "version": "v0.11.0-dev.320.10+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.312.2+issue.26",
+  "version": "v0.11.0-dev.313.3+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "marucs-diet",
   "private": true,
   "type": "module",
-  "version": "v0.11.0-dev.314.4+issue.26",
+  "version": "v0.11.0-dev.315.5+issue.26",
   "scripts": {
     "dev": "vinxi dev",
     "build": "vinxi build",

--- a/src/modules/diet/day-diet/application/dayDiet.test.ts
+++ b/src/modules/diet/day-diet/application/dayDiet.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { getPreviousDayDiets } from './dayDiet'
+import type { DayDiet } from '~/modules/diet/day-diet/domain/dayDiet'
+
+const makeDay = (target_day: string, id: number): DayDiet => ({
+  id,
+  target_day,
+  owner: 1,
+  meals: [],
+  __type: 'DayDiet',
+})
+
+describe('getPreviousDayDiets', () => {
+  it('returns all days before selectedDay, ordered descending', () => {
+    const days = [
+      makeDay('2024-01-01', 1),
+      makeDay('2024-01-05', 2),
+      makeDay('2024-01-03', 3),
+      makeDay('2024-01-10', 4),
+    ]
+    const result = getPreviousDayDiets(days, '2024-01-06')
+    expect(result.map((d) => d.target_day)).toEqual([
+      '2024-01-05',
+      '2024-01-03',
+      '2024-01-01',
+    ])
+  })
+
+  it('returns empty if no previous days', () => {
+    const days = [makeDay('2024-01-10', 1)]
+    const result = getPreviousDayDiets(days, '2024-01-01')
+    expect(result).toEqual([])
+  })
+
+  it('ignores days equal to selectedDay', () => {
+    const days = [makeDay('2024-01-01', 1), makeDay('2024-01-02', 2)]
+    const result = getPreviousDayDiets(days, '2024-01-01')
+    expect(result).toEqual([])
+  })
+})

--- a/src/modules/diet/day-diet/application/dayDiet.ts
+++ b/src/modules/diet/day-diet/application/dayDiet.ts
@@ -159,3 +159,19 @@ export async function deleteDayDiet(dayId: DayDiet['id']): Promise<void> {
     throw error
   }
 }
+
+/**
+ * Returns all previous DayDiet objects before the given target day, ordered by descending date.
+ *
+ * @param dayDiets - List of all DayDiet objects (should be sorted ascending by date)
+ * @param selectedDay - The YYYY-MM-DD string to compare against
+ * @returns Array of DayDiet objects before selectedDay, ordered by descending date
+ */
+export function getPreviousDayDiets(
+  dayDiets: readonly DayDiet[],
+  selectedDay: string,
+): DayDiet[] {
+  return dayDiets
+    .filter((day) => Date.parse(day.target_day) < Date.parse(selectedDay))
+    .sort((a, b) => Date.parse(b.target_day) - Date.parse(a.target_day))
+}

--- a/src/routes/diet.tsx
+++ b/src/routes/diet.tsx
@@ -38,7 +38,7 @@ export default function DietPage() {
       )}
       <DayMeals
         selectedDay={targetDay()}
-        mode={mode()}
+        mode={'summary'}
         onRequestEditMode={handleRequestEditMode}
       />
       <BottomNavigation />

--- a/src/routes/diet.tsx
+++ b/src/routes/diet.tsx
@@ -1,5 +1,10 @@
-import { targetDay } from '~/modules/diet/day-diet/application/dayDiet'
+import { Show } from 'solid-js'
+import {
+  currentDayDiet,
+  targetDay,
+} from '~/modules/diet/day-diet/application/dayDiet'
 import { BottomNavigation } from '~/sections/common/components/BottomNavigation'
+import DayMacros from '~/sections/day-diet/components/DayMacros'
 import DayMeals from '~/sections/day-diet/components/DayMeals'
 import TopBar from '~/sections/day-diet/components/TopBar'
 
@@ -8,6 +13,12 @@ export default function DietPage() {
     <div class="mx-auto sm:w-3/4 md:w-4/5 lg:w-1/2 xl:w-1/3">
       {/* Top bar with date picker and user icon */}
       <TopBar selectedDay={targetDay()} />
+      <Show when={currentDayDiet()} fallback={<div>Loading...</div>}>
+        {(currentDayDiet) => (
+          <DayMacros dayDiet={currentDayDiet()} class="mb-4" />
+        )}
+      </Show>
+      {/* Display meals for the selected day */}
       <DayMeals selectedDay={targetDay()} />
       <BottomNavigation />
     </div>

--- a/src/routes/diet.tsx
+++ b/src/routes/diet.tsx
@@ -7,8 +7,13 @@ import { BottomNavigation } from '~/sections/common/components/BottomNavigation'
 import DayMacros from '~/sections/day-diet/components/DayMacros'
 import DayMeals from '~/sections/day-diet/components/DayMeals'
 import TopBar from '~/sections/day-diet/components/TopBar'
+import { getTodayYYYYMMDD } from '~/shared/utils/date'
+import { Alert } from '~/sections/common/components/Alert'
 
 export default function DietPage() {
+  const today = getTodayYYYYMMDD()
+  const locked = () => targetDay() !== today
+
   return (
     <div class="mx-auto sm:w-3/4 md:w-4/5 lg:w-1/2 xl:w-1/3">
       {/* Top bar with date picker and user icon */}
@@ -19,7 +24,12 @@ export default function DietPage() {
         )}
       </Show>
       {/* Display meals for the selected day */}
-      <DayMeals selectedDay={targetDay()} />
+      {locked() && (
+        <Alert class="mt-2" color="yellow">
+          Mostrando refeições do dia {targetDay()}!
+        </Alert>
+      )}
+      <DayMeals selectedDay={targetDay()} locked={locked()} />
       <BottomNavigation />
     </div>
   )

--- a/src/routes/diet.tsx
+++ b/src/routes/diet.tsx
@@ -1,7 +1,8 @@
-import { Show } from 'solid-js'
+import { Show, createSignal, createEffect } from 'solid-js'
 import {
   currentDayDiet,
   targetDay,
+  setTargetDay,
 } from '~/modules/diet/day-diet/application/dayDiet'
 import { BottomNavigation } from '~/sections/common/components/BottomNavigation'
 import DayMacros from '~/sections/day-diet/components/DayMacros'
@@ -12,7 +13,15 @@ import { Alert } from '~/sections/common/components/Alert'
 
 export default function DietPage() {
   const today = getTodayYYYYMMDD()
-  const mode = () => (targetDay() === today ? 'edit' : 'read-only')
+  const [mode, setMode] = createSignal<'edit' | 'read-only' | 'summary'>('edit')
+
+  function handleRequestEditMode() {
+    setMode('edit')
+  }
+
+  createEffect(() => {
+    setMode(targetDay() === today ? 'edit' : 'read-only')
+  })
 
   return (
     <div class="mx-auto sm:w-3/4 md:w-4/5 lg:w-1/2 xl:w-1/3">
@@ -27,7 +36,11 @@ export default function DietPage() {
           Mostrando refeições do dia {targetDay()}!
         </Alert>
       )}
-      <DayMeals selectedDay={targetDay()} mode={mode()} />
+      <DayMeals
+        selectedDay={targetDay()}
+        mode={mode()}
+        onRequestEditMode={handleRequestEditMode}
+      />
       <BottomNavigation />
     </div>
   )

--- a/src/routes/diet.tsx
+++ b/src/routes/diet.tsx
@@ -2,7 +2,6 @@ import { Show, createSignal, createEffect } from 'solid-js'
 import {
   currentDayDiet,
   targetDay,
-  setTargetDay,
 } from '~/modules/diet/day-diet/application/dayDiet'
 import { BottomNavigation } from '~/sections/common/components/BottomNavigation'
 import DayMacros from '~/sections/day-diet/components/DayMacros'
@@ -38,7 +37,7 @@ export default function DietPage() {
       )}
       <DayMeals
         selectedDay={targetDay()}
-        mode={'summary'}
+        mode={mode()}
         onRequestEditMode={handleRequestEditMode}
       />
       <BottomNavigation />

--- a/src/routes/diet.tsx
+++ b/src/routes/diet.tsx
@@ -12,24 +12,22 @@ import { Alert } from '~/sections/common/components/Alert'
 
 export default function DietPage() {
   const today = getTodayYYYYMMDD()
-  const locked = () => targetDay() !== today
+  const mode = () => (targetDay() === today ? 'edit' : 'read-only')
 
   return (
     <div class="mx-auto sm:w-3/4 md:w-4/5 lg:w-1/2 xl:w-1/3">
-      {/* Top bar with date picker and user icon */}
       <TopBar selectedDay={targetDay()} />
       <Show when={currentDayDiet()} fallback={<div>Loading...</div>}>
         {(currentDayDiet) => (
           <DayMacros dayDiet={currentDayDiet()} class="mb-4" />
         )}
       </Show>
-      {/* Display meals for the selected day */}
-      {locked() && (
+      {mode() !== 'edit' && (
         <Alert class="mt-2" color="yellow">
           Mostrando refeições do dia {targetDay()}!
         </Alert>
       )}
-      <DayMeals selectedDay={targetDay()} locked={locked()} />
+      <DayMeals selectedDay={targetDay()} mode={mode()} />
       <BottomNavigation />
     </div>
   )

--- a/src/routes/test-app.tsx
+++ b/src/routes/test-app.tsx
@@ -231,7 +231,6 @@ export default function TestApp() {
             setTargetDay(value?.startDate as string)
           }}
         />
-        <BackIcon />
         <TestField />
         <TestModal />
         <TestConfirmModal />

--- a/src/sections/common/components/Modal.tsx
+++ b/src/sections/common/components/Modal.tsx
@@ -1,5 +1,4 @@
 import { createEffect, mergeProps, type JSXElement } from 'solid-js'
-import { BackIcon } from '~/sections/common/components/icons/BackIcon'
 import { useModalContext } from '~/sections/common/context/ModalContext'
 import { cn } from '~/shared/cn'
 import { DarkToaster } from './DarkToaster'
@@ -63,22 +62,12 @@ export const Modal = (_props: ModalProps) => {
   )
 }
 
+// TODO: Remove BackButton from ModalHeader, standardize modal closing
 function ModalHeader(_props: { title: JSXElement; backButton?: boolean }) {
   const props = mergeProps({ backButton: true }, _props)
-  const { setVisible } = useModalContext()
 
   return (
     <div class="flex gap-2">
-      {props.backButton && (
-        <button
-          class="btn btn-sm btn-ghost btn-circle"
-          onClick={() => {
-            setVisible(false)
-          }}
-        >
-          <BackIcon />
-        </button>
-      )}
       <h3 class="text-lg font-bold text-white my-auto w-full">{props.title}</h3>
     </div>
   )

--- a/src/sections/day-diet/components/CopyLastDayButton.tsx
+++ b/src/sections/day-diet/components/CopyLastDayButton.tsx
@@ -1,97 +1,170 @@
-import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
+import { ModalContextProvider } from '~/sections/common/context/ModalContext'
+import { Modal } from '~/sections/common/components/Modal'
+import Datepicker from '~/sections/datepicker/components/Datepicker'
+import { createSignal, type Accessor } from 'solid-js'
+import { type DayDiet } from '~/modules/diet/day-diet/domain/dayDiet'
 import {
-  createNewDayDiet,
-  type DayDiet,
-} from '~/modules/diet/day-diet/domain/dayDiet'
-import {
-  dayDiets,
+  getPreviousDayDiets,
   insertDayDiet,
   updateDayDiet,
+  dayDiets,
 } from '~/modules/diet/day-diet/application/dayDiet'
-import { Show, createEffect, createSignal, type Accessor } from 'solid-js'
-import { showError } from '~/modules/toast/application/toastManager'
+import { calcCalories, calcDayMacros } from '~/legacy/utils/macroMath'
+import { getMacroTargetForDay } from '~/modules/diet/macro-target/application/macroTarget'
+import { stringToDate } from '~/shared/utils/date'
+import DayMacros from '~/sections/day-diet/components/DayMacros'
+import DayMeals from '~/sections/day-diet/components/DayMeals'
+import { For, Show } from 'solid-js'
+import {
+  showError,
+  showSuccess,
+} from '~/modules/toast/application/toastManager'
+
+function DayMacrosResumo(props: { dayDiet: DayDiet }) {
+  const macroTarget = getMacroTargetForDay(
+    stringToDate(props.dayDiet.target_day),
+  )
+  if (!macroTarget) return <div>Sem meta de macros</div>
+  const macros = calcDayMacros(props.dayDiet)
+  const targetCalories = calcCalories(macroTarget)
+  return (
+    <div class="mb-2">
+      <div class="font-bold mb-1">Macros</div>
+      <div>
+        Calorias: {Math.round(calcCalories(macros))} /{' '}
+        {Math.round(targetCalories)} kcal
+      </div>
+      <div>
+        Carboidrato: {Math.round(macros.carbs)} /{' '}
+        {Math.round(macroTarget.carbs)}g
+      </div>
+      <div>
+        Proteína: {Math.round(macros.protein)} /{' '}
+        {Math.round(macroTarget.protein)}g
+      </div>
+      <div>
+        Gordura: {Math.round(macros.fat)} / {Math.round(macroTarget.fat)}g
+      </div>
+    </div>
+  )
+}
+
+function DayMealsResumo(props: { dayDiet: DayDiet }) {
+  return (
+    <div>
+      <div class="font-bold mb-1">Refeições</div>
+      <For each={props.dayDiet.meals}>
+        {(meal) => (
+          <div class="mb-1">
+            <div class="font-semibold">{meal.name}</div>
+            <ul class="ml-4 list-disc">
+              <For each={meal.groups}>{(group) => <li>{group.name}</li>}</For>
+            </ul>
+          </div>
+        )}
+      </For>
+    </div>
+  )
+}
 
 export function CopyLastDayButton(props: {
   dayDiet: Accessor<DayDiet | undefined>
   selectedDay: string
 }) {
-  const { show: showConfirmModal } = useConfirmModalContext()
+  // Estado do modal
+  const [modalOpen, setModalOpen] = createSignal(false)
+  // Estado para data selecionada no datepicker
+  const [selectedCopyDay, setSelectedCopyDay] = createSignal<string | null>(
+    null,
+  )
 
-  const [lastDay, setLastDay] = createSignal<DayDiet | undefined>(undefined)
-
-  createEffect(() => {
-    const days = [...dayDiets()]
-    const newLastDay = days
-      .reverse()
-      .find((day) => Date.parse(day.target_day) < Date.parse(props.selectedDay))
-    setLastDay(newLastDay)
-  })
+  const previousDays = () => getPreviousDayDiets(dayDiets(), props.selectedDay)
+  const selectedDayDiet = () =>
+    previousDays().find((d) => d.target_day === selectedCopyDay())
 
   return (
     <>
-      <Show
-        when={lastDay()}
-        keyed
-        fallback={
-          <>
+      {/* Botão para abrir modal de cópia */}
+      <button
+        class="btn-primary btn mt-3 min-w-full rounded px-4 py-2 font-bold text-white"
+        onClick={() => setModalOpen(true)}
+      >
+        Copiar dia anterior
+      </button>
+      {/* Modal de seleção de dia anterior */}
+      <ModalContextProvider visible={modalOpen} setVisible={setModalOpen}>
+        <Modal>
+          <div class="flex flex-col gap-4 min-h-[500px]">
+            <h2 class="text-lg font-bold">
+              Selecione um dia anterior para copiar
+            </h2>
+            <Datepicker
+              asSingle={true}
+              useRange={false}
+              displayFormat="YYYY-MM-DD"
+              value={{
+                startDate: selectedCopyDay(),
+                endDate: selectedCopyDay(),
+              }}
+              onChange={(v) => {
+                let val = v?.startDate ?? null
+                if (val instanceof Date) {
+                  val = val.toISOString().slice(0, 10)
+                }
+                setSelectedCopyDay(val)
+              }}
+              maxDate={new Date(props.selectedDay)}
+            />
+            <Show when={selectedDayDiet()}>
+              <div class="border-t pt-4 mt-2">
+                <h3 class="font-semibold mb-2">Resumo do dia selecionado</h3>
+                <DayMacrosResumo dayDiet={selectedDayDiet()!} />
+                <DayMealsResumo dayDiet={selectedDayDiet()!} />
+              </div>
+            </Show>
+            {/* Botão de confirmação/cópia */}
             <button
-              class="btn-error btn mt-3 min-w-full rounded px-4 py-2 font-bold text-white"
+              class="btn-primary btn mt-4 w-full"
+              disabled={!selectedDayDiet()}
               onClick={() => {
-                showError(
-                  `Não foi possível encontrar um dia anterior a ${props.selectedDay}`,
-                )
+                if (!selectedDayDiet()) return
+                void (async () => {
+                  const copyFrom = selectedDayDiet()!
+                  const allDays = dayDiets()
+                  const existing = allDays.find(
+                    (d) => d.target_day === props.selectedDay,
+                  )
+                  const newDay = {
+                    target_day: props.selectedDay,
+                    owner: copyFrom.owner,
+                    meals: copyFrom.meals,
+                    __type: 'NewDayDiet' as const,
+                  }
+                  try {
+                    if (existing) {
+                      await updateDayDiet(existing.id, newDay)
+                    } else {
+                      await insertDayDiet(newDay)
+                    }
+                    setModalOpen(false)
+                    showSuccess('Dia copiado com sucesso!', {
+                      context: 'user-action',
+                    })
+                  } catch (e) {
+                    showError(
+                      e,
+                      { context: 'user-action' },
+                      'Erro ao copiar dia',
+                    )
+                  }
+                })()
               }}
             >
-              Copiar dia anterior: não encontrado! :(
+              Copiar para {props.selectedDay}
             </button>
-          </>
-        }
-      >
-        {(lastDay) => (
-          <button
-            class="btn-primary btn mt-3 min-w-full rounded px-4 py-2 font-bold text-white"
-            onClick={() => {
-              const day_ = props.dayDiet()
-              if (day_ !== undefined) {
-                showConfirmModal({
-                  title: 'Sobrescrever dia',
-                  body: 'Tem certeza que deseja SOBRESCREVER este dia?',
-                  actions: [
-                    {
-                      text: 'Cancelar',
-                      onClick: () => undefined,
-                    },
-                    {
-                      text: 'Sobrescrever',
-                      primary: true,
-                      onClick: () => {
-                        void updateDayDiet(
-                          day_.id,
-                          createNewDayDiet({
-                            ...lastDay,
-                            target_day: props.selectedDay,
-                          }),
-                        )
-                      },
-                    },
-                  ],
-                })
-                return
-              }
-
-              void insertDayDiet(
-                createNewDayDiet({
-                  ...lastDay,
-                  target_day: props.selectedDay,
-                }),
-              )
-            }}
-          >
-            {/* //TODO:   Allow copying any past day, not just latest one. */}
-            Copiar dia anterior ({lastDay.target_day})
-          </button>
-        )}
-      </Show>
+          </div>
+        </Modal>
+      </ModalContextProvider>
     </>
   )
 }

--- a/src/sections/day-diet/components/CopyLastDayButton.tsx
+++ b/src/sections/day-diet/components/CopyLastDayButton.tsx
@@ -12,7 +12,7 @@ import { Show, createEffect, createSignal, type Accessor } from 'solid-js'
 import { showError } from '~/modules/toast/application/toastManager'
 
 export function CopyLastDayButton(props: {
-  dayDiet: Accessor<DayDiet | undefined> // TODO:   Rename all 'day' to 'dayDiet' on entire project.
+  dayDiet: Accessor<DayDiet | undefined>
   selectedDay: string
 }) {
   const { show: showConfirmModal } = useConfirmModalContext()

--- a/src/sections/day-diet/components/CopyLastDayButton.tsx
+++ b/src/sections/day-diet/components/CopyLastDayButton.tsx
@@ -16,9 +16,6 @@ import {
 
 import DayMacros from '~/sections/day-diet/components/DayMacros'
 import DayMeals from '~/sections/day-diet/components/DayMeals'
-import { stringToDate } from '~/shared/utils/date'
-import { calcCalories, calcDayMacros } from '~/legacy/utils/macroMath'
-import { getMacroTargetForDay } from '~/modules/diet/macro-target/application/macroTarget'
 
 export function CopyLastDayButton(props: {
   dayDiet: Accessor<DayDiet | undefined>

--- a/src/sections/day-diet/components/CopyLastDayButton.tsx
+++ b/src/sections/day-diet/components/CopyLastDayButton.tsx
@@ -1,7 +1,7 @@
 import { ModalContextProvider } from '~/sections/common/context/ModalContext'
 import { Modal } from '~/sections/common/components/Modal'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
-import { createSignal, type Accessor } from 'solid-js'
+import { createSignal, type Accessor, Show } from 'solid-js'
 import { type DayDiet } from '~/modules/diet/day-diet/domain/dayDiet'
 import {
   getPreviousDayDiets,
@@ -9,63 +9,16 @@ import {
   updateDayDiet,
   dayDiets,
 } from '~/modules/diet/day-diet/application/dayDiet'
-import { calcCalories, calcDayMacros } from '~/legacy/utils/macroMath'
-import { getMacroTargetForDay } from '~/modules/diet/macro-target/application/macroTarget'
-import { stringToDate } from '~/shared/utils/date'
-import DayMacros from '~/sections/day-diet/components/DayMacros'
-import DayMeals from '~/sections/day-diet/components/DayMeals'
-import { For, Show } from 'solid-js'
 import {
   showError,
   showSuccess,
 } from '~/modules/toast/application/toastManager'
 
-function DayMacrosResumo(props: { dayDiet: DayDiet }) {
-  const macroTarget = getMacroTargetForDay(
-    stringToDate(props.dayDiet.target_day),
-  )
-  if (!macroTarget) return <div>Sem meta de macros</div>
-  const macros = calcDayMacros(props.dayDiet)
-  const targetCalories = calcCalories(macroTarget)
-  return (
-    <div class="mb-2">
-      <div class="font-bold mb-1">Macros</div>
-      <div>
-        Calorias: {Math.round(calcCalories(macros))} /{' '}
-        {Math.round(targetCalories)} kcal
-      </div>
-      <div>
-        Carboidrato: {Math.round(macros.carbs)} /{' '}
-        {Math.round(macroTarget.carbs)}g
-      </div>
-      <div>
-        Proteína: {Math.round(macros.protein)} /{' '}
-        {Math.round(macroTarget.protein)}g
-      </div>
-      <div>
-        Gordura: {Math.round(macros.fat)} / {Math.round(macroTarget.fat)}g
-      </div>
-    </div>
-  )
-}
-
-function DayMealsResumo(props: { dayDiet: DayDiet }) {
-  return (
-    <div>
-      <div class="font-bold mb-1">Refeições</div>
-      <For each={props.dayDiet.meals}>
-        {(meal) => (
-          <div class="mb-1">
-            <div class="font-semibold">{meal.name}</div>
-            <ul class="ml-4 list-disc">
-              <For each={meal.groups}>{(group) => <li>{group.name}</li>}</For>
-            </ul>
-          </div>
-        )}
-      </For>
-    </div>
-  )
-}
+import DayMacros from '~/sections/day-diet/components/DayMacros'
+import DayMeals from '~/sections/day-diet/components/DayMeals'
+import { stringToDate } from '~/shared/utils/date'
+import { calcCalories, calcDayMacros } from '~/legacy/utils/macroMath'
+import { getMacroTargetForDay } from '~/modules/diet/macro-target/application/macroTarget'
 
 export function CopyLastDayButton(props: {
   dayDiet: Accessor<DayDiet | undefined>
@@ -118,8 +71,11 @@ export function CopyLastDayButton(props: {
             <Show when={selectedDayDiet()}>
               <div class="border-t pt-4 mt-2">
                 <h3 class="font-semibold mb-2">Resumo do dia selecionado</h3>
-                <DayMacrosResumo dayDiet={selectedDayDiet()!} />
-                <DayMealsResumo dayDiet={selectedDayDiet()!} />
+                <DayMacros dayDiet={selectedDayDiet()} />
+                <DayMeals
+                  dayDiet={selectedDayDiet()}
+                  selectedDay={selectedDayDiet()?.target_day ?? ''}
+                />
               </div>
             </Show>
             {/* Botão de confirmação/cópia */}

--- a/src/sections/day-diet/components/CopyLastDayButton.tsx
+++ b/src/sections/day-diet/components/CopyLastDayButton.tsx
@@ -72,6 +72,7 @@ export function CopyLastDayButton(props: {
                 <DayMeals
                   dayDiet={selectedDayDiet()}
                   selectedDay={selectedDayDiet()?.target_day ?? ''}
+                  mode="summary"
                 />
               </div>
             </Show>

--- a/src/sections/day-diet/components/DayMacros.tsx
+++ b/src/sections/day-diet/components/DayMacros.tsx
@@ -6,29 +6,28 @@ import { getMacroTargetForDay } from '~/modules/diet/macro-target/application/ma
 import { showError } from '~/modules/toast/application/toastManager'
 import { Progress } from '~/sections/common/components/Progress'
 import { stringToDate } from '~/shared/utils/date'
+import { type DayDiet } from '~/modules/diet/day-diet/domain/dayDiet'
 
-export default function DayMacros(props: { class?: string }) {
+export default function DayMacros(props: {
+  class?: string
+  dayDiet?: DayDiet
+}) {
   const macroSignals = () => {
-    const currentDayDiet_ = currentDayDiet()
-    if (currentDayDiet_ === null) {
+    const day = props.dayDiet ?? currentDayDiet()
+    if (!day) {
       showError(new Error('Dia atual não encontrado'), {
         audience: 'system',
       })
       return null
     }
-
-    const macroTarget_ = getMacroTargetForDay(
-      stringToDate(currentDayDiet_.target_day),
-    )
+    const macroTarget_ = getMacroTargetForDay(stringToDate(day.target_day))
     if (macroTarget_ === null) {
       showError(new Error('Meta de macros não encontrada'), {
         audience: 'system',
       })
       return null
     }
-
-    const dayMacros = calcDayMacros(currentDayDiet_)
-
+    const dayMacros = calcDayMacros(day)
     return {
       macroTarget: macroTarget_,
       macros: dayMacros,

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -168,6 +168,7 @@ export default function DayMeals(props: {
               day={() => neverNullDayDiet}
               visible={itemGroupEditModalVisible}
               setVisible={setItemGroupEditModalVisible}
+              mode={props.mode}
             />
             <For each={neverNullDayDiet.meals}>
               {(meal) => (
@@ -177,6 +178,7 @@ export default function DayMeals(props: {
                   header={
                     <MealEditViewHeader
                       onUpdateMeal={(meal) => {
+                        if (props.mode === 'summary') return
                         const current = resolvedDayDiet()
                         if (current === null) {
                           console.error('resolvedDayDiet is null!')
@@ -189,31 +191,40 @@ export default function DayMeals(props: {
                           )
                         })
                       }}
+                      mode={props.mode}
                     />
                   }
                   content={
                     <MealEditViewContent
                       onEditItemGroup={(item) => {
+                        if (props.mode === 'summary') return
                         handleEditItemGroup(meal, item)
                       }}
+                      mode={props.mode}
                     />
                   }
                   actions={
-                    <MealEditViewActions
-                      onNewItem={() => {
-                        handleNewItemButton(meal)
-                      }}
-                    />
+                    props.mode === 'summary' ? undefined : (
+                      <MealEditViewActions
+                        onNewItem={() => {
+                          handleNewItemButton(meal)
+                        }}
+                      />
+                    )
                   }
                 />
               )}
             </For>
 
-            <CopyLastDayButton
-              dayDiet={() => neverNullDayDiet}
-              selectedDay={props.selectedDay}
-            />
-            <DeleteDayButton day={() => neverNullDayDiet} />
+            {props.mode !== 'summary' && (
+              <>
+                <CopyLastDayButton
+                  dayDiet={() => neverNullDayDiet}
+                  selectedDay={props.selectedDay}
+                />
+                <DeleteDayButton day={() => neverNullDayDiet} />
+              </>
+            )}
           </>
         )}
       </Show>
@@ -225,6 +236,7 @@ function ExternalItemGroupEditModal(props: {
   visible: Accessor<boolean>
   setVisible: Setter<boolean>
   day: Accessor<DayDiet>
+  mode?: 'edit' | 'read-only' | 'summary'
 }) {
   createEffect(() => {
     if (!props.visible()) {
@@ -275,6 +287,7 @@ function ExternalItemGroupEditModal(props: {
                 '[DayMeals] (<ItemGroupEditModal/>) onRefetch called!',
               )
             }}
+            mode={props.mode}
           />
         </ModalContextProvider>
       )}

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -18,7 +18,6 @@ import { type ItemGroup } from '~/modules/diet/item-group/domain/itemGroup'
 import { updateMeal } from '~/modules/diet/meal/application/meal'
 import { type Meal } from '~/modules/diet/meal/domain/meal'
 import { showError } from '~/modules/toast/application/toastManager'
-import { Alert } from '~/sections/common/components/Alert'
 import { ModalContextProvider } from '~/sections/common/context/ModalContext'
 import { CopyLastDayButton } from '~/sections/day-diet/components/CopyLastDayButton'
 import DayNotFound from '~/sections/day-diet/components/DayNotFound'
@@ -32,7 +31,6 @@ import {
 } from '~/sections/meal/components/MealEditView'
 import { ExternalTemplateSearchModal } from '~/sections/search/components/ExternalTemplateSearchModal'
 import { formatError } from '~/shared/formatError'
-import { getTodayYYYYMMDD } from '~/shared/utils/date'
 
 type EditSelection = {
   meal: Meal
@@ -57,20 +55,17 @@ const [newItemSelection, setNewItemSelection] =
 export default function DayMeals(props: {
   dayDiet?: DayDiet
   selectedDay: string
+  locked?: boolean
 }) {
-  const today = getTodayYYYYMMDD()
-  const showingToday = () => today === props.selectedDay
-
-  const [dayExplicitlyUnlocked] = createSignal(false)
-  const dayLocked = () => !showingToday() && !dayExplicitlyUnlocked()
-
+  // Signals para modais (devem ser mantidos)
   const [itemGroupEditModalVisible, setItemGroupEditModalVisible] =
     createSignal(false)
+
   const [templateSearchModalVisible, setTemplateSearchModalVisible] =
     createSignal(false)
 
   const handleEditItemGroup = (meal: Meal, itemGroup: ItemGroup) => {
-    if (dayLocked()) {
+    if (props.locked === true) {
       showError('Dia bloqueado, não é possível editar')
       return
     }
@@ -79,7 +74,7 @@ export default function DayMeals(props: {
   }
 
   const handleUpdateMeal = async (day: DayDiet, meal: Meal) => {
-    if (dayLocked()) {
+    if (props.locked === true) {
       showError('Dia bloqueado, não é possível editar')
       return
     }
@@ -87,7 +82,7 @@ export default function DayMeals(props: {
   }
 
   const handleNewItemButton = (meal: Meal) => {
-    if (dayLocked()) {
+    if (props.locked === true) {
       showError('Dia bloqueado, não é possível editar')
       return
     }
@@ -137,43 +132,6 @@ export default function DayMeals(props: {
             visible={itemGroupEditModalVisible}
             setVisible={setItemGroupEditModalVisible}
           />
-          {/* DayMacros removed: now must be rendered independently by parent */}
-          <Show when={!showingToday()}>
-            {(_) => (
-              <>
-                <Alert class="mt-2" color="yellow">
-                  Mostrando refeições do dia {props.selectedDay}!
-                </Alert>
-                {/* <Show when={dayLocked()}>
-                  {(_) => (
-                    <>
-                      <Alert class="mt-2 outline" color="blue">
-                        Hoje é dia <b>{today}</b>{' '}
-                        <a
-                          class="font-bold text-blue-500 hover:cursor-pointer "
-                          onClick={() => {
-                            setTargetDay(today)
-                          }}
-                        >
-                          Mostrar refeições de hoje
-                        </a>{' '}
-                        ou{' '}
-                        <a
-                          class="font-bold text-red-600 hover:cursor-pointer "
-                          onClick={() => {
-                            setDayExplicitlyUnlocked(true)
-                          }}
-                        >
-                          {' '}
-                          Desbloquear dia {props.selectedDay}
-                        </a>
-                      </Alert>
-                    </>
-                  )}
-                </Show> */}
-              </>
-            )}
-          </Show>
           <For each={neverNullDayDiet.meals}>
             {(meal) => (
               <MealEditView

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -51,13 +51,13 @@ const [newItemSelection, setNewItemSelection] =
  * If dayDiet is provided, uses it; otherwise, uses the currentDayDiet from application state.
  * @param props.dayDiet Optional DayDiet to display (overrides selectedDay)
  * @param props.selectedDay The day string (YYYY-MM-DD) to display
+ * @param props.mode Display mode: 'edit', 'read-only', or 'summary'.
  */
 export default function DayMeals(props: {
   dayDiet?: DayDiet
   selectedDay: string
-  locked?: boolean
+  mode?: 'edit' | 'read-only' | 'summary'
 }) {
-  // Signals para modais (devem ser mantidos)
   const [itemGroupEditModalVisible, setItemGroupEditModalVisible] =
     createSignal(false)
 
@@ -65,7 +65,7 @@ export default function DayMeals(props: {
     createSignal(false)
 
   const handleEditItemGroup = (meal: Meal, itemGroup: ItemGroup) => {
-    if (props.locked === true) {
+    if (props.mode !== 'edit') {
       showError('Dia bloqueado, não é possível editar')
       return
     }
@@ -74,7 +74,7 @@ export default function DayMeals(props: {
   }
 
   const handleUpdateMeal = async (day: DayDiet, meal: Meal) => {
-    if (props.locked === true) {
+    if (props.mode !== 'edit') {
       showError('Dia bloqueado, não é possível editar')
       return
     }
@@ -82,7 +82,7 @@ export default function DayMeals(props: {
   }
 
   const handleNewItemButton = (meal: Meal) => {
-    if (props.locked === true) {
+    if (props.mode !== 'edit') {
       showError('Dia bloqueado, não é possível editar')
       return
     }

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -7,10 +7,7 @@ import {
   createSignal,
   untrack,
 } from 'solid-js'
-import {
-  currentDayDiet,
-  setTargetDay,
-} from '~/modules/diet/day-diet/application/dayDiet'
+import { currentDayDiet } from '~/modules/diet/day-diet/application/dayDiet'
 import { type DayDiet } from '~/modules/diet/day-diet/domain/dayDiet'
 import {
   deleteItemGroup,
@@ -24,7 +21,6 @@ import { showError } from '~/modules/toast/application/toastManager'
 import { Alert } from '~/sections/common/components/Alert'
 import { ModalContextProvider } from '~/sections/common/context/ModalContext'
 import { CopyLastDayButton } from '~/sections/day-diet/components/CopyLastDayButton'
-import DayMacros from '~/sections/day-diet/components/DayMacros'
 import DayNotFound from '~/sections/day-diet/components/DayNotFound'
 import { DeleteDayButton } from '~/sections/day-diet/components/DeleteDayButton'
 import { ItemGroupEditModal } from '~/sections/item-group/components/ItemGroupEditModal'
@@ -65,7 +61,7 @@ export default function DayMeals(props: {
   const today = getTodayYYYYMMDD()
   const showingToday = () => today === props.selectedDay
 
-  const [dayExplicitlyUnlocked, setDayExplicitlyUnlocked] = createSignal(false)
+  const [dayExplicitlyUnlocked] = createSignal(false)
   const dayLocked = () => !showingToday() && !dayExplicitlyUnlocked()
 
   const [itemGroupEditModalVisible, setItemGroupEditModalVisible] =
@@ -141,17 +137,14 @@ export default function DayMeals(props: {
             visible={itemGroupEditModalVisible}
             setVisible={setItemGroupEditModalVisible}
           />
-          <DayMacros
-            class="mt-3 border-b-2 border-gray-800 pb-4"
-            dayDiet={props.dayDiet}
-          />
+          {/* DayMacros removed: now must be rendered independently by parent */}
           <Show when={!showingToday()}>
             {(_) => (
               <>
                 <Alert class="mt-2" color="yellow">
                   Mostrando refeições do dia {props.selectedDay}!
                 </Alert>
-                <Show when={dayLocked()}>
+                {/* <Show when={dayLocked()}>
                   {(_) => (
                     <>
                       <Alert class="mt-2 outline" color="blue">
@@ -177,7 +170,7 @@ export default function DayMeals(props: {
                       </Alert>
                     </>
                   )}
-                </Show>
+                </Show> */}
               </>
             )}
           </Show>

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -68,12 +68,8 @@ export default function DayMeals(props: {
 
   const [showConfirmEdit, setShowConfirmEdit] = createSignal(false)
 
-  const handleEditItemGroup = (meal: Meal, itemGroup: ItemGroup) => {
-    if (props.mode === 'summary') return
-    if (props.mode !== 'edit') {
-      setShowConfirmEdit(true)
-      return
-    }
+  const handleRequestViewItemGroup = (meal: Meal, itemGroup: ItemGroup) => {
+    // Always open the modal for any mode, but ItemGroupEditModal will respect the mode prop
     setEditSelection({ meal, itemGroup })
     setItemGroupEditModalVisible(true)
   }
@@ -196,9 +192,8 @@ export default function DayMeals(props: {
                   }
                   content={
                     <MealEditViewContent
-                      onEditItemGroup={(item) => {
-                        if (props.mode === 'summary') return
-                        handleEditItemGroup(meal, item)
+                      onRequestViewItemGroup={(item) => {
+                        handleRequestViewItemGroup(meal, item)
                       }}
                       mode={props.mode}
                     />

--- a/src/sections/food-item/components/ItemListView.tsx
+++ b/src/sections/food-item/components/ItemListView.tsx
@@ -11,12 +11,18 @@ import {
 } from '~/sections/food-item/components/ItemView'
 import { handleClipboardError } from '~/shared/error/errorHandler'
 
-export function ItemListView(_props: {
+export type ItemListViewProps = {
   items: Accessor<readonly Item[]>
   onItemClick: ItemViewProps['onClick']
   makeHeaderFn?: (item: Item) => ItemViewProps['header']
-}) {
-  const props = mergeProps({ makeHeaderFn: () => <DefaultHeader /> }, _props)
+  mode?: 'edit' | 'read-only' | 'summary'
+}
+
+export function ItemListView(_props: ItemListViewProps) {
+  const props = mergeProps(
+    { makeHeaderFn: () => <DefaultHeader mode={_props.mode} /> },
+    _props,
+  )
   return (
     <>
       <For each={props.items()}>
@@ -29,6 +35,7 @@ export function ItemListView(_props: {
                 macroOverflow={() => ({ enable: false })}
                 header={props.makeHeaderFn(item)}
                 nutritionalInfo={<ItemNutritionalInfo />}
+                mode={props.mode}
               />
             </div>
           )
@@ -38,23 +45,25 @@ export function ItemListView(_props: {
   )
 }
 
-function DefaultHeader() {
+function DefaultHeader(props: { mode?: 'edit' | 'read-only' | 'summary' }) {
   const clipboard = useClipboard()
   return (
     <HeaderWithActions
       name={<ItemName />}
       primaryActions={
-        <ItemCopyButton
-          onCopyItem={(item) => {
-            clipboard.write(JSON.stringify(item), (error) => {
-              handleClipboardError(error, {
-                component: 'ItemListView',
-                operation: 'copyItem',
-                additionalData: { itemId: item.reference },
+        props.mode === 'summary' ? null : (
+          <ItemCopyButton
+            onCopyItem={(item) => {
+              clipboard.write(JSON.stringify(item), (error) => {
+                handleClipboardError(error, {
+                  component: 'ItemListView',
+                  operation: 'copyItem',
+                  additionalData: { itemId: item.reference },
+                })
               })
-            })
-          }}
-        />
+            }}
+          />
+        )
       }
     />
   )

--- a/src/sections/food-item/components/ItemView.tsx
+++ b/src/sections/food-item/components/ItemView.tsx
@@ -50,6 +50,7 @@ export type ItemViewProps = {
   nutritionalInfo?: JSXElement
   class?: string
   onClick?: (item: TemplateItem) => void
+  mode?: 'edit' | 'read-only' | 'summary'
 }
 
 export function ItemView(props: ItemViewProps) {

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -645,7 +645,6 @@ function Title(props: {
   return (
     <div class="flex flex-col gap-1">
       <div class="flex items-center justify-between gap-2">
-        <span class="text-lg font-bold text-white">Grupo:</span>
         <GroupNameEdit
           group={props.group}
           setGroup={props.setGroup}

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -419,7 +419,7 @@ function Title(props: {
         <Show
           when={isEditingName() && props.mode === 'edit'}
           fallback={
-            <div class="flex items-center gap-2">
+            <div class="flex items-center gap-1 min-w-0">
               <span
                 class="truncate text-lg font-semibold text-white"
                 title={props.group().name}
@@ -431,6 +431,7 @@ function Title(props: {
                   class="btn btn-xs btn-ghost px-1"
                   aria-label="Editar nome do grupo"
                   onClick={() => setIsEditingName(true)}
+                  style={{ 'line-height': '1' }}
                 >
                   ✏️
                 </button>
@@ -438,9 +439,15 @@ function Title(props: {
             </div>
           }
         >
-          <div class="flex items-center gap-2 w-full">
+          <form
+            class="flex items-center gap-1 min-w-0 w-full"
+            onSubmit={(e) => {
+              e.preventDefault()
+              setIsEditingName(false)
+            }}
+          >
             <input
-              class="input input-xs w-full"
+              class="input input-xs w-full max-w-[180px]"
               type="text"
               value={props.group().name}
               onChange={(e) =>
@@ -459,19 +466,25 @@ function Title(props: {
                 }, 0)
               }}
               disabled={props.mode !== 'edit'}
+              style={{
+                'padding-top': '2px',
+                'padding-bottom': '2px',
+                'font-size': '1rem',
+              }}
             />
             <button
-              class="btn btn-xs btn-primary"
+              class="btn btn-xs btn-primary px-2"
               aria-label="Salvar nome do grupo"
               onClick={() => setIsEditingName(false)}
-              type="button"
+              type="submit"
+              style={{ 'min-width': '48px', height: '28px' }}
             >
               Salvar
             </button>
-          </div>
+          </form>
         </Show>
       </div>
-      <div class="text-sm text-gray-400">
+      <div class="text-sm text-gray-400 mt-1">
         Em <span class="text-green-500">"{props.targetMealName}"</span>
       </div>
       <div class="text-xs text-gray-400">

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -100,6 +100,7 @@ export type ItemGroupEditModalProps = {
   onRefetch: () => void
   group: Accessor<ItemGroup>
   setGroup: (group: ItemGroup | null) => void
+  mode?: 'edit' | 'read-only' | 'summary'
 }
 
 export const ItemGroupEditModal = (props: ItemGroupEditModalProps) => {
@@ -382,6 +383,7 @@ const InnerItemGroupEditModal = (props: ItemGroupEditModalProps) => {
                 setTemplateSearchModalVisible={setTemplateSearchModalVisible}
                 recipeEditModalVisible={recipeEditModalVisible}
                 setRecipeEditModalVisible={setRecipeEditModalVisible}
+                mode={props.mode}
               />
             </Modal.Content>
             <Modal.Footer>
@@ -420,6 +422,7 @@ function Body(props: {
   setItemEditModalVisible: Setter<boolean>
   templateSearchModalVisible: Accessor<boolean>
   setTemplateSearchModalVisible: Setter<boolean>
+  mode?: 'edit' | 'read-only' | 'summary'
 }) {
   const { show: showConfirmModal } = useConfirmModalContext()
 
@@ -662,18 +665,21 @@ function Body(props: {
               props.setItemEditModalVisible(true)
               // }
             }}
+            mode={props.mode}
             makeHeaderFn={(item) => (
               <HeaderWithActions
                 name={<ItemName />}
                 primaryActions={
-                  <>
-                    <ItemCopyButton
-                      onCopyItem={(item) => {
-                        writeToClipboard(JSON.stringify(item))
-                      }}
-                    />
-                    <ItemFavorite foodId={item.reference} />
-                  </>
+                  props.mode === 'summary' ? null : (
+                    <>
+                      <ItemCopyButton
+                        onCopyItem={(item) => {
+                          writeToClipboard(JSON.stringify(item))
+                        }}
+                      />
+                      <ItemFavorite foodId={item.reference} />
+                    </>
+                  )
                 }
               />
             )}

--- a/src/sections/item-group/components/ItemGroupEditModal.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModal.tsx
@@ -492,185 +492,181 @@ function Body(props: {
                       ref.blur()
                     }, 0)
                   }}
+                  disabled={props.mode !== 'edit'}
                 />
               </div>
-
-              <div class="flex gap-2 px-2">
-                <Show when={hasValidPastableOnClipboardShared()}>
-                  {(_) => (
-                    <div
-                      class={
-                        'btn-ghost btn ml-auto mt-1 px-2 text-white hover:scale-105'
-                      }
-                      onClick={() => {
-                        // TODO: Support editing complex recipes
-                        if (isRecipeTooComplex(props.recipe())) {
-                          showError(
-                            'Os itens desse grupo não podem ser editados. Motivo: a receita é muito complexa, ainda não é possível editar receitas complexas',
-                          )
-                          return
+              {props.mode === 'edit' && (
+                <div class="flex gap-2 px-2">
+                  <Show when={hasValidPastableOnClipboardShared()}>
+                    {(_) => (
+                      <div
+                        class={
+                          'btn-ghost btn ml-auto mt-1 px-2 text-white hover:scale-105'
                         }
-                        handlePasteShared()
-                      }}
-                    >
-                      <PasteIcon />
-                    </div>
-                  )}
-                </Show>
-
-                <Show when={isSimpleItemGroup(group())}>
-                  {(_) => (
-                    <>
-                      <button
-                        class="my-auto ml-auto"
                         onClick={() => {
-                          const exec = async () => {
-                            const newRecipe = createNewRecipe({
-                              name:
-                                group().name.length > 0
-                                  ? group().name
-                                  : 'Nova receita (a partir de um grupo)',
-                              items: deepCopy(group().items) ?? [],
-                              owner: currentUserId(),
-                            })
-
-                            const insertedRecipe = await insertRecipe(newRecipe)
-
-                            if (insertedRecipe === null) {
-                              return
-                            }
-
-                            setGroup(
-                              setItemGroupRecipe(group(), insertedRecipe.id),
-                            )
-
-                            props.setRecipeEditModalVisible(true)
-                          }
-
-                          exec().catch((err) => {
+                          // TODO: Support editing complex recipes
+                          if (isRecipeTooComplex(props.recipe())) {
                             showError(
-                              `Falha ao criar receita a partir de grupo: ${formatError(err)}`,
+                              'Os itens desse grupo não podem ser editados. Motivo: a receita é muito complexa, ainda não é possível editar receitas complexas',
                             )
-                          })
+                            return
+                          }
+                          handlePasteShared()
                         }}
                       >
-                        <ConvertToRecipeIcon />
-                      </button>
-                    </>
-                  )}
-                </Show>
+                        <PasteIcon />
+                      </div>
+                    )}
+                  </Show>
+                  <Show when={isSimpleItemGroup(group())}>
+                    {(_) => (
+                      <>
+                        <button
+                          class="my-auto ml-auto"
+                          onClick={() => {
+                            const exec = async () => {
+                              const newRecipe = createNewRecipe({
+                                name:
+                                  group().name.length > 0
+                                    ? group().name
+                                    : 'Nova receita (a partir de um grupo)',
+                                items: deepCopy(group().items) ?? [],
+                                owner: currentUserId(),
+                              })
 
-                <Show
-                  when={(() => {
-                    const group_ = group()
-                    return isRecipedItemGroup(group_) && group_
-                  })()}
-                >
-                  {(group) => (
-                    <>
-                      <Show when={props.recipe()}>
-                        {(recipe) => (
-                          <>
-                            <Show
-                              when={isRecipedGroupUpToDate(group(), recipe())}
-                            >
-                              {(_) => (
-                                <button
-                                  class="my-auto ml-auto"
-                                  onClick={() => {
-                                    // TODO:   Create recipe for groups that don't have one
-                                    props.setRecipeEditModalVisible(true)
-                                  }}
-                                >
-                                  <RecipeIcon />
-                                </button>
-                              )}
-                            </Show>
+                              const insertedRecipe =
+                                await insertRecipe(newRecipe)
 
-                            <Show
-                              when={!isRecipedGroupUpToDate(group(), recipe())}
-                            >
-                              {(_) => (
-                                <button
-                                  class="my-auto ml-auto hover:animate-pulse"
-                                  onClick={() => {
-                                    if (props.recipe() === null) {
-                                      return
-                                    }
+                              if (insertedRecipe === null) {
+                                return
+                              }
 
-                                    const newGroup = setItemGroupItems(
-                                      group(),
-                                      recipe().items,
-                                    )
+                              setGroup(
+                                setItemGroupRecipe(group(), insertedRecipe.id),
+                              )
 
-                                    setGroup(newGroup)
-                                  }}
-                                >
-                                  <DownloadIcon />
-                                </button>
-                              )}
-                            </Show>
+                              props.setRecipeEditModalVisible(true)
+                            }
 
-                            <button
-                              class="my-auto ml-auto hover:animate-pulse"
-                              onClick={() => {
-                                askUnlinkRecipe(
-                                  'Deseja desvincular a receita?',
-                                  {
-                                    showConfirmModal,
-                                    group,
-                                    setGroup,
-                                  },
-                                )
-                              }}
-                            >
-                              <BrokenLink />
-                            </button>
-                          </>
-                        )}
-                      </Show>
-
-                      <Show when={props.recipe() === null}>
-                        <>Receita não encontrada</>
-                      </Show>
-                    </>
-                  )}
-                </Show>
-              </div>
+                            exec().catch((err) => {
+                              showError(
+                                `Falha ao criar receita a partir de grupo: ${formatError(err)}`,
+                              )
+                            })
+                          }}
+                        >
+                          <ConvertToRecipeIcon />
+                        </button>
+                      </>
+                    )}
+                  </Show>
+                  <Show
+                    when={(() => {
+                      const group_ = group()
+                      return isRecipedItemGroup(group_) && group_
+                    })()}
+                  >
+                    {(group) => (
+                      <>
+                        <Show when={props.recipe()}>
+                          {(recipe) => (
+                            <>
+                              <Show
+                                when={isRecipedGroupUpToDate(group(), recipe())}
+                              >
+                                {(_) => (
+                                  <button
+                                    class="my-auto ml-auto"
+                                    onClick={() => {
+                                      // TODO:   Create recipe for groups that don't have one
+                                      props.setRecipeEditModalVisible(true)
+                                    }}
+                                  >
+                                    <RecipeIcon />
+                                  </button>
+                                )}
+                              </Show>
+                              <Show
+                                when={
+                                  !isRecipedGroupUpToDate(group(), recipe())
+                                }
+                              >
+                                {(_) => (
+                                  <button
+                                    class="my-auto ml-auto hover:animate-pulse"
+                                    onClick={() => {
+                                      if (props.recipe() === null) {
+                                        return
+                                      }
+                                      const newGroup = setItemGroupItems(
+                                        group(),
+                                        recipe().items,
+                                      )
+                                      setGroup(newGroup)
+                                    }}
+                                  >
+                                    <DownloadIcon />
+                                  </button>
+                                )}
+                              </Show>
+                              <button
+                                class="my-auto ml-auto hover:animate-pulse"
+                                onClick={() => {
+                                  askUnlinkRecipe(
+                                    'Deseja desvincular a receita?',
+                                    {
+                                      showConfirmModal,
+                                      group,
+                                      setGroup,
+                                    },
+                                  )
+                                }}
+                              >
+                                <BrokenLink />
+                              </button>
+                            </>
+                          )}
+                        </Show>
+                        <Show when={props.recipe() === null}>
+                          <>Receita não encontrada</>
+                        </Show>
+                      </>
+                    )}
+                  </Show>
+                </div>
+              )}
             </div>
           </div>
-
           <ItemListView
             items={() => group().items}
-            // TODO:   Check if this margin was lost.
-            //   className="mt-4"
-            onItemClick={(item) => {
-              // TODO:   Allow user to edit recipe
-              if (isTemplateItemRecipe(item)) {
-                showError(
-                  'Ainda não é possível editar receitas! Funcionalidade em desenvolvimento',
-                )
-                return
-              }
-
-              // TODO: Support editing complex recipes
-              if (isRecipeTooComplex(props.recipe())) {
-                showError(
-                  'Os itens desse grupo não podem ser editados. Motivo: a receita é muito complexa, ainda não é possível editar receitas complexas',
-                )
-                return
-              }
-
-              setEditSelection({ item })
-              props.setItemEditModalVisible(true)
-              // }
-            }}
+            onItemClick={
+              props.mode === 'edit'
+                ? (item) => {
+                    if (isTemplateItemRecipe(item)) {
+                      // TODO:   Allow user to edit recipe
+                      showError(
+                        'Ainda não é possível editar receitas! Funcionalidade em desenvolvimento',
+                      )
+                      return
+                    }
+                    if (isRecipeTooComplex(props.recipe())) {
+                      // TODO: Support editing complex recipes
+                      showError(
+                        'Os itens desse grupo não podem ser editados. Motivo: a receita é muito complexa, ainda não é possível editar receitas complexas',
+                      )
+                      return
+                    }
+                    setEditSelection({ item })
+                    props.setItemEditModalVisible(true)
+                  }
+                : undefined
+            }
             mode={props.mode}
             makeHeaderFn={(item) => (
               <HeaderWithActions
                 name={<ItemName />}
                 primaryActions={
-                  props.mode === 'summary' ? null : (
+                  props.mode === 'edit' ? (
                     <>
                       <ItemCopyButton
                         onCopyItem={(item) => {
@@ -679,20 +675,21 @@ function Body(props: {
                       />
                       <ItemFavorite foodId={item.reference} />
                     </>
-                  )
+                  ) : null
                 }
               />
             )}
           />
-
-          <button
-            class="mt-3 min-w-full rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
-            onClick={() => {
-              props.setTemplateSearchModalVisible(true)
-            }}
-          >
-            Adicionar item
-          </button>
+          {props.mode === 'edit' && (
+            <button
+              class="mt-3 min-w-full rounded bg-blue-500 px-4 py-2 font-bold text-white hover:bg-blue-700"
+              onClick={() => {
+                props.setTemplateSearchModalVisible(true)
+              }}
+            >
+              Adicionar item
+            </button>
+          )}
           <Show when={recipedGroup()}>
             {(recipedGroup) => (
               <PreparedQuantityWrapper

--- a/src/sections/item-group/components/ItemGroupListView.tsx
+++ b/src/sections/item-group/components/ItemGroupListView.tsx
@@ -11,10 +11,13 @@ import { useClipboard } from '~/sections/common/hooks/useClipboard'
 import { HeaderWithActions } from '~/sections/common/components/HeaderWithActions'
 import { type Accessor, For } from 'solid-js'
 
-export function ItemGroupListView(props: {
+export type ItemGroupListViewProps = {
   itemGroups: Accessor<ItemGroup[]>
   onItemClick: ItemGroupViewProps['onClick']
-}) {
+  mode?: 'edit' | 'read-only' | 'summary'
+}
+
+export function ItemGroupListView(props: ItemGroupListViewProps) {
   const clipboard = useClipboard()
   console.debug('[ItemGroupListView] - Rendering')
   return (
@@ -24,22 +27,25 @@ export function ItemGroupListView(props: {
           <ItemGroupView
             itemGroup={() => group}
             onClick={props.onItemClick}
+            mode={props.mode}
             header={
               <HeaderWithActions
                 name={<ItemGroupName group={() => group} />}
                 primaryActions={
-                  <ItemGroupCopyButton
-                    group={() => group}
-                    onCopyItemGroup={(group) => {
-                      clipboard.write(JSON.stringify(group), (err) => {
-                        handleClipboardError(err, {
-                          component: 'ItemGroupListView',
-                          operation: 'copyItemGroup',
-                          additionalData: { groupId: group.id },
+                  props.mode === 'summary' ? null : (
+                    <ItemGroupCopyButton
+                      group={() => group}
+                      onCopyItemGroup={(group) => {
+                        clipboard.write(JSON.stringify(group), (err) => {
+                          handleClipboardError(err, {
+                            component: 'ItemGroupListView',
+                            operation: 'copyItemGroup',
+                            additionalData: { groupId: group.id },
+                          })
                         })
-                      })
-                    }}
-                  />
+                      }}
+                    />
+                  )
                 }
               />
             }

--- a/src/sections/item-group/components/ItemGroupView.tsx
+++ b/src/sections/item-group/components/ItemGroupView.tsx
@@ -33,6 +33,7 @@ export type ItemGroupViewProps = {
   nutritionalInfo?: JSXElement
   className?: string
   onClick?: (itemGroup: ItemGroup) => void
+  mode?: 'edit' | 'read-only' | 'summary'
 }
 
 export function ItemGroupView(props: ItemGroupViewProps) {

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -30,13 +30,20 @@ export type MealEditViewProps = {
   /**
    * @deprecated
    */
-  header?: JSXElement
-  content?: JSXElement
+  header?:
+    | JSXElement
+    | ((props: { mode?: 'edit' | 'read-only' | 'summary' }) => JSXElement)
+  content?:
+    | JSXElement
+    | ((props: { mode?: 'edit' | 'read-only' | 'summary' }) => JSXElement)
   /**
    * @deprecated
    */
-  actions?: JSXElement
+  actions?:
+    | JSXElement
+    | ((props: { mode?: 'edit' | 'read-only' | 'summary' }) => JSXElement)
   class?: string
+  mode?: 'edit' | 'read-only' | 'summary'
 }
 
 // TODO:   move this function
@@ -52,12 +59,16 @@ export type MealEditViewProps = {
 export function MealEditView(props: MealEditViewProps) {
   return (
     <MealContextProvider meal={() => props.meal}>
-      <div
-        class={`bg-gray-800 p-3 ${props.class ?? ''}`} // TODO:   use cn on all classes that use props.class
-      >
-        {props.header}
-        {props.content}
-        {props.actions}
+      <div class={`bg-gray-800 p-3 ${props.class ?? ''}`}>
+        {typeof props.header === 'function'
+          ? props.header({ mode: props.mode })
+          : props.header}
+        {typeof props.content === 'function'
+          ? props.content({ mode: props.mode })
+          : props.content}
+        {typeof props.actions === 'function'
+          ? props.actions({ mode: props.mode })
+          : props.actions}
       </div>
     </MealContextProvider>
   )
@@ -138,7 +149,7 @@ export function MealEditViewHeader(props: {
 }
 
 export function MealEditViewContent(props: {
-  onEditItemGroup: (item: ItemGroup) => void
+  onRequestViewItemGroup: (item: ItemGroup) => void
   mode?: 'edit' | 'read-only' | 'summary'
 }) {
   const { meal } = useMealContext()
@@ -153,7 +164,7 @@ export function MealEditViewContent(props: {
   return (
     <ItemGroupListView
       itemGroups={() => meal().groups}
-      onItemClick={props.onEditItemGroup}
+      onItemClick={props.onRequestViewItemGroup}
       mode={props.mode}
     />
   )

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -65,6 +65,7 @@ export function MealEditView(props: MealEditViewProps) {
 
 export function MealEditViewHeader(props: {
   onUpdateMeal: (meal: Meal) => void
+  mode?: 'edit' | 'read-only' | 'summary'
 }) {
   const { show: showConfirmModal } = useConfirmModalContext()
   const { meal } = useMealContext()
@@ -118,16 +119,18 @@ export function MealEditViewHeader(props: {
             <h5 class="text-3xl">{mealSignal().name}</h5>
             <p class="italic text-gray-400">{mealCalories().toFixed(0)}kcal</p>
           </div>
-          <ClipboardActionButtons
-            canCopy={
-              !hasValidPastableOnClipboard() && mealSignal().groups.length > 0
-            }
-            canPaste={hasValidPastableOnClipboard()}
-            canClear={mealSignal().groups.length > 0}
-            onCopy={handleCopy}
-            onPaste={handlePaste}
-            onClear={onClearItems}
-          />
+          {props.mode !== 'summary' && (
+            <ClipboardActionButtons
+              canCopy={
+                !hasValidPastableOnClipboard() && mealSignal().groups.length > 0
+              }
+              canPaste={hasValidPastableOnClipboard()}
+              canClear={mealSignal().groups.length > 0}
+              onCopy={handleCopy}
+              onPaste={handlePaste}
+              onClear={onClearItems}
+            />
+          )}
         </div>
       )}
     </Show>
@@ -136,6 +139,7 @@ export function MealEditViewHeader(props: {
 
 export function MealEditViewContent(props: {
   onEditItemGroup: (item: ItemGroup) => void
+  mode?: 'edit' | 'read-only' | 'summary'
 }) {
   const { meal } = useMealContext()
 
@@ -149,9 +153,8 @@ export function MealEditViewContent(props: {
   return (
     <ItemGroupListView
       itemGroups={() => meal().groups}
-      onItemClick={(...args) => {
-        props.onEditItemGroup(...args)
-      }}
+      onItemClick={props.onEditItemGroup}
+      mode={props.mode}
     />
   )
 }


### PR DESCRIPTION
Enhance the day-diet functionality by allowing users to copy previous days with confirmation and feedback. Refactor components for better separation of concerns, ensuring compatibility with existing features. Improve item-group editing experience with centralized logic and streamlined UI. Update documentation and clean up configuration settings. All tests and checks pass.

Closes #26