### PR TITLE
feat: add confirmation dialogs before deleting weight and measure entries

### DIFF
--- a/src/sections/profile/measure/components/MeasureView.tsx
+++ b/src/sections/profile/measure/components/MeasureView.tsx
@@ -15,6 +15,7 @@ import { useDateField, useFloatField } from '~/sections/common/hooks/useField'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
 import { formatError } from '~/shared/formatError'
 import { adjustToTimezone } from '~/shared/utils/date/dateUtils'
+import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 
 /**
  * Renders a capsule view for editing and saving a single Measure.
@@ -33,6 +34,7 @@ export function MeasureView(props: {
   const waistField = useFloatField(() => props.measure.waist)
   const hipField = useFloatField(() => props.measure.hip)
   const neckField = useFloatField(() => props.measure.neck)
+  const { show: showConfirmModal } = useConfirmModalContext()
 
   const handleSave = ({
     date,
@@ -78,15 +80,33 @@ export function MeasureView(props: {
   }
 
   const handleDelete = () => {
-    const afterDelete = () => {
-      props.onRefetchMeasures()
-    }
-    deleteMeasure(props.measure.id)
-      .then(afterDelete)
-      .catch((error) => {
-        console.error(error)
-        showError('Erro ao deletar: \n' + JSON.stringify(error, null, 2))
-      })
+    showConfirmModal({
+      title: 'Confirmar exclusão',
+      body: 'Tem certeza que deseja excluir esta medida? Esta ação não pode ser desfeita.',
+      actions: [
+        {
+          text: 'Cancelar',
+          onClick: () => {},
+        },
+        {
+          text: 'Excluir',
+          primary: true,
+          onClick: () => {
+            const afterDelete = () => {
+              props.onRefetchMeasures()
+            }
+            deleteMeasure(props.measure.id)
+              .then(afterDelete)
+              .catch((error) => {
+                showError(
+                  'Erro ao deletar: \n' + JSON.stringify(error, null, 2),
+                )
+              })
+          },
+        },
+      ],
+      hasBackdrop: true,
+    })
   }
 
   return (

--- a/src/sections/weight/components/WeightEvolution.tsx
+++ b/src/sections/weight/components/WeightEvolution.tsx
@@ -28,6 +28,7 @@ import { TrashIcon } from '~/sections/common/components/icons/TrashIcon'
 import { useDateField, useFloatField } from '~/sections/common/hooks/useField'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
 import { adjustToTimezone, dateToYYYYMMDD } from '~/shared/utils/date'
+import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 
 // Utils
 function getCandlePeriod(type: string): { days: number; count: number } {
@@ -334,6 +335,7 @@ function WeightView(props: { weight: Weight }) {
   const dateField = useDateField(targetTimestampSignal)
   const weightSignal = () => props.weight.weight
   const weightField = useFloatField(weightSignal)
+  const { show: showConfirmModal } = useConfirmModalContext()
   const handleSave = ({
     dateValue,
     weightValue,
@@ -402,7 +404,24 @@ function WeightView(props: { weight: Weight }) {
           <button
             class="btn cursor-pointer uppercase btn-ghost my-auto focus:ring-2 focus:ring-blue-400 border-none text-white bg-ghost hover:bg-slate-800 py-2 px-2 w-full sm:w-auto"
             onClick={() => {
-              void deleteWeight(props.weight.id)
+              showConfirmModal({
+                title: 'Confirmar exclusão',
+                body: 'Tem certeza que deseja excluir este peso? Esta ação não pode ser desfeita.',
+                actions: [
+                  {
+                    text: 'Cancelar',
+                    onClick: () => {},
+                  },
+                  {
+                    text: 'Excluir',
+                    primary: true,
+                    onClick: () => {
+                      void deleteWeight(props.weight.id)
+                    },
+                  },
+                ],
+                hasBackdrop: true,
+              })
             }}
           >
             <TrashIcon />


### PR DESCRIPTION
This PR introduces confirmation dialogs to enhance user safety before deleting entries in two sections:

- **Weight Section**: A confirmation dialog now appears before a user deletes a weight entry, preventing accidental deletions.
- **Profile/Measure Section**: A confirmation dialog is shown before deleting a measure entry, ensuring users confirm their intent.

These changes improve the user experience by reducing the risk of unintended data loss. No breaking changes are introduced.

closes #433