### PR TITLE
fix(recipe): allow empty arrays for items and improve PR automation (#726)

### DIFF
--- a/.github/prompts/commit.prompt.md
+++ b/.github/prompts/commit.prompt.md
@@ -1,15 +1,15 @@
 ---
-description: 'Analyze modified files and diffs, then generate a concise, conventional commit message in English. Ensure clarity, security, and adherence to best practices.'
+description: 'Analyze staged changes and generate a concise, conventional commit message in English. Ensure clarity, security, and adherence to best practices.'
 mode: 'agent'
 tools: ['terminal']
 ---
 
 # Commit Message Agent
 
-Automatically execute the necessary git commands to obtain the list of modified, added, or deleted files and their before/after contents in the current repository.
+Automatically execute the necessary git commands to obtain the list of staged, modified, added, or deleted files and their before/after contents in the current repository.
 
-- Use as few shell commands as possible to gather all relevant information (e.g., `git diff --patch-with-stat --summary HEAD` and `git status --porcelain=v1`).
-- For new or modified files, generate a list of relevant file paths and use a shell for-loop to display their full contents, for example:
+- Use as few shell commands as possible to gather all relevant information about staged changes (e.g., `git diff --cached --patch-with-stat --summary HEAD` and `git status --porcelain=v1`).
+- For new or modified staged files, generate a list of relevant file paths and use a shell for-loop to display their full contents, for example:
 
 ```zsh
 for file in <file1> <file2> <file3>; do
@@ -17,7 +17,7 @@ for file in <file1> <file2> <file3>; do
 done
 ```
 
-- Analyze the changes and generate a short, clear, conventional commit message in English. The message must:
+- Analyze the staged changes and generate a short, clear, conventional commit message in English. The message must:
   - Summarize the main purpose of the changes.
   - Mention relevant files or modules if needed.
   - Follow the [conventional commits](https://www.conventionalcommits.org/) style (e.g., feat:, fix:, refactor:, test:, chore:).
@@ -33,10 +33,10 @@ Output the commit message as a markdown code block:
 <commit message in English, following the conventional commits style, summarizing the main change>
 ````
 
-Then, automatically execute the shell command to commit the changes with the generated message:
+Then, always execute the shell command to commit the staged changes with the generated message using the terminal (do not just print the command), unless you have a doubt and need to ask the user for clarification. Use:
 
 ````shell
-git commit -am "<generated commit message>"
+git commit -m "<generated commit message>"
 ````
 
 Replace <generated commit message> with the actual message you generated. This helps the user quickly apply the suggested commit in their workflow.

--- a/.github/prompts/pull-request.prompt.md
+++ b/.github/prompts/pull-request.prompt.md
@@ -1,10 +1,10 @@
 ---
-description: 'Review all changes from HEAD to the nearest rc/** branch (local or remote), and generate a PR title, description, labels, milestone, and closes issues. Handles missing rc/** branches gracefully.'
+description: 'Review all changes from HEAD to the nearest rc/** branch (local or remote), push unpushed commits, and generate and open a PR using gh. Confirm PR details with the user before creation. PR is created to the nearest rc/** branch.'
 mode: 'agent'
 tools: ['codebase', 'git', 'gh']
 ---
 
-# Pull Request Review & Generation Agent
+# Pull Request Review, Push & Creation Agent
 
 Analyze all modifications in the codebase from the current `HEAD` to the nearest base branch matching `rc/**` (e.g., `rc/v0.11.0`), searching both local and remote branches. If no such branch exists, prompt the user for the correct base branch or fail gracefully.
 
@@ -30,4 +30,14 @@ Analyze all modifications in the codebase from the current `HEAD` to the nearest
 - Output the PR Title and PR Description in two separate Markdown code blocks. Output labels and milestone as plain text lists for user convenience.
 - Output all results in English.
 - If any required information is missing or ambiguous, ask clarifying questions before proceeding.
+
+---
+
+## Additional Push & PR Creation Steps
+
+- After generating the PR title, description, labels, and milestone, check for any local commits that have not been pushed to the remote branch. If there are unpushed commits, push them before proceeding.
+- Before creating the PR, display the PR title, description, labels, and milestone to the user and ask for confirmation to proceed.
+- Once confirmed, use the `gh` CLI to create a pull request from the current branch to the nearest `rc/**` branch. The PR should use the generated title and description. Reference [pull-request-gh.prompt.md](./pull-request-gh.prompt.md) for best practices on using the `gh` command.
+- After creating the PR, display the PR URL or summary to the user.
+- If any step fails (e.g., push fails, `gh` command fails), output a clear error message and stop.
 

--- a/src/modules/diet/recipe/domain/recipe.ts
+++ b/src/modules/diet/recipe/domain/recipe.ts
@@ -13,12 +13,7 @@ export const newRecipeSchema = z.object({
     required_error: "O campo 'owner' da receita é obrigatório.",
     invalid_type_error: "O campo 'owner' da receita deve ser um número.",
   }),
-  items: itemSchema
-    .array()
-    .refine((arr) => Array.isArray(arr) && arr.length > 0, {
-      message:
-        "O campo 'items' da receita deve ser uma lista de itens e não pode ser vazio.",
-    }),
+  items: itemSchema.array(),
   prepared_multiplier: z
     .number({
       required_error: "O campo 'prepared_multiplier' da receita é obrigatório.",
@@ -42,13 +37,7 @@ export const recipeSchema = z.object({
     required_error: "O campo 'owner' da receita é obrigatório.",
     invalid_type_error: "O campo 'owner' da receita deve ser um número.",
   }),
-  items: itemSchema
-    .array()
-    .refine((arr) => Array.isArray(arr) && arr.length > 0, {
-      message:
-        "O campo 'items' da receita deve ser uma lista de itens e não pode ser vazio.",
-    })
-    .readonly(),
+  items: itemSchema.array().readonly(),
   prepared_multiplier: z
     .number({
       required_error: "O campo 'prepared_multiplier' da receita é obrigatório.",


### PR DESCRIPTION
### What was changed and why\n\n- Updated recipe schemas to allow empty arrays for items, resolving validation issues and improving flexibility for users with no initial items.\n- Enhanced the pull-request prompt to automate pushing unpushed commits, confirming PR details, and creating PRs using the `gh` CLI, streamlining the workflow for contributors.\n- Documentation was updated to clarify the commit prompt and staged changes handling.\n\n### Context\n\nThis PR directly addresses issue #726 by ensuring recipes can be created or updated with empty item arrays, preventing errors and improving user experience. The PR automation improvements further support efficient contribution and review processes.\n\n### Implementation details\n\n- Schema validation for recipes now accepts empty arrays for items.\n- .github/prompts/pull-request.prompt.md was updated for automation and clarity.\n- Documentation was revised for better guidance.\n\ncloses #726