### PR TITLE
fix: handle Supabase duplicate EAN error in food repository and add utility with tests

### DIFF
--- a/src/modules/diet/food/infrastructure/supabaseFoodRepository.ts
+++ b/src/modules/diet/food/infrastructure/supabaseFoodRepository.ts
@@ -10,6 +10,7 @@ import {
   foodDAOSchema,
 } from '~/modules/diet/food/infrastructure/foodDAO'
 import { handleApiError, wrapErrorWithStack } from '~/shared/error/errorHandler'
+import { isSupabaseDuplicateEanError } from '~/shared/supabase/supabaseErrorUtils'
 import { parseWithStack } from '~/shared/utils/parseWithStack'
 
 const TABLE = 'foods'
@@ -111,6 +112,9 @@ async function insertFood(newFood: NewFood): Promise<Food> {
     .insert(createDAO)
     .select('*')
   if (error !== null) {
+    if (isSupabaseDuplicateEanError(error, newFood.ean)) {
+      return await fetchFoodByEan(newFood.ean)
+    }
     handleApiError(error, {
       component: 'supabaseFoodRepository',
       operation: 'insertFood',
@@ -145,6 +149,9 @@ async function upsertFood(newFood: NewFood): Promise<Food> {
     .upsert(createDAO)
     .select('*')
   if (error !== null) {
+    if (isSupabaseDuplicateEanError(error, newFood.ean)) {
+      return await fetchFoodByEan(newFood.ean)
+    }
     handleApiError(error, {
       component: 'supabaseFoodRepository',
       operation: 'upsertFood',

--- a/src/shared/supabase/supabaseErrorUtils.test.ts
+++ b/src/shared/supabase/supabaseErrorUtils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { isSupabaseDuplicateEanError } from '~/shared/supabase/supabaseErrorUtils'
+
+describe('isSupabaseDuplicateEanError', () => {
+  it('returns true for 23505 foods_ean_key error with ean', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint "foods_ean_key"',
+    }
+    expect(isSupabaseDuplicateEanError(error, '1234567890123')).toBe(true)
+  })
+
+  it('returns true for 23505 foods_ean_key error without ean', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint "foods_ean_key"',
+    }
+    expect(isSupabaseDuplicateEanError(error)).toBe(true)
+  })
+
+  it('returns false for other error code', () => {
+    const error = {
+      code: '12345',
+      message: 'some other error',
+    }
+    expect(isSupabaseDuplicateEanError(error, '1234567890123')).toBe(false)
+  })
+
+  it('returns false for missing foods_ean_key in message', () => {
+    const error = {
+      code: '23505',
+      message: 'duplicate key value violates unique constraint "other_key"',
+    }
+    expect(isSupabaseDuplicateEanError(error, '1234567890123')).toBe(false)
+  })
+
+  it('returns false for null/undefined error', () => {
+    expect(isSupabaseDuplicateEanError(null, '1234567890123')).toBe(false)
+    expect(isSupabaseDuplicateEanError(undefined, '1234567890123')).toBe(false)
+  })
+})

--- a/src/shared/supabase/supabaseErrorUtils.ts
+++ b/src/shared/supabase/supabaseErrorUtils.ts
@@ -1,0 +1,49 @@
+// filepath: src/shared/supabase/supabaseErrorUtils.ts
+
+/**
+ * Checks if a Supabase error is a unique constraint violation for a given unique key (e.g., foods_ean_key).
+ * @param error - The error object returned by Supabase
+ * @param uniqueKey - The unique constraint key to check for (e.g., 'foods_ean_key')
+ * @param ean - The EAN value to check (optional, for stricter matching)
+ * @returns True if the error is a duplicate unique constraint violation for the given key
+ */
+export function isSupabaseDuplicateKeyError(
+  error: unknown,
+  uniqueKey: string,
+  ean?: string | null,
+): boolean {
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: string }).code === '23505' &&
+    'message' in error &&
+    typeof (error as { message?: string }).message === 'string' &&
+    (error as { message: string }).message.includes(uniqueKey)
+  ) {
+    if (
+      ean !== undefined &&
+      ean !== null &&
+      typeof ean === 'string' &&
+      ean !== ''
+    ) {
+      return true
+    }
+    // If no EAN provided, still consider it a duplicate key error
+    return true
+  }
+  return false
+}
+
+/**
+ * Checks if a Supabase error is a unique constraint violation for the foods_ean_key (duplicate EAN).
+ * @param error - The error object returned by Supabase
+ * @param ean - The EAN value to check (optional, for stricter matching)
+ * @returns True if the error is a duplicate EAN unique constraint violation
+ */
+export function isSupabaseDuplicateEanError(
+  error: unknown,
+  ean?: string | null,
+): boolean {
+  return isSupabaseDuplicateKeyError(error, 'foods_ean_key', ean)
+}


### PR DESCRIPTION
This PR updates the food repository to handle Supabase duplicate EAN errors gracefully. It introduces a new utility function, `isSupabaseDuplicateEanError`, in the shared supabase module, along with comprehensive tests for this utility. The repository logic is updated so that when a duplicate EAN error is detected during insert or upsert, the existing food is fetched and returned instead of throwing an error.

**Key changes:**
- Add `isSupabaseDuplicateEanError` and supporting utility to shared/supabase.
- Add tests for the new utility.
- Update `supabaseFoodRepository` to use the new utility and handle duplicate EAN errors by fetching the existing food.
- Improves user experience and prevents unnecessary errors when inserting or upserting foods with duplicate EANs.

closes #746