### PR TITLE
feat(food): improve food search with diacritic-insensitive and composed multi-word matching

### DIFF
--- a/.github/prompts/milestone-complexity-labeler.prompt.md
+++ b/.github/prompts/milestone-complexity-labeler.prompt.md
@@ -1,0 +1,56 @@
+---
+description: 'Prompt to identify issues in a milestone, assess their complexity, and apply appropriate complexity labels.'
+mode: 'agent'
+tools: ['codebase', 'github-api', 'gh', 'terminal']
+---
+
+# Milestone Issue Complexity Labeling Agent
+
+## Objective
+
+Given a milestone, identify all issues associated with it, assess the complexity of each issue, and ensure that each issue is labeled with the correct complexity label. The agent must confirm the proposed complexity plan with the user before applying labels.
+
+## Instructions
+
+1. **Identify Issues in Milestone**
+   - Use the `gh` CLI to retrieve all milestones and issues assigned to the specified milestone.
+   - Example: `gh issue list --milestone <milestone-name>` and `gh api repos/:owner/:repo/milestones`.
+   - Present a list of these issues (with titles and IDs) to the user.
+
+2. **Assess Complexity**
+   - For each issue, analyze its description, requirements, and any relevant discussion to estimate its complexity.
+   - Use the following labels to classify complexity:
+     - `complexity-low`
+     - `complexity-medium`
+     - `complexity-high`
+     - `complexity-very-high`
+   - Provide a brief justification for each complexity assessment.
+
+3. **Confirm Complexity Plan**
+   - Present the proposed complexity labels and justifications to the user for confirmation.
+   - If the user requests changes, update the plan accordingly.
+
+4. **Apply Labels**
+   - Once confirmed, apply the appropriate complexity label to each issue.
+   - Ensure that only one complexity label is present per issue.
+   - Remove any outdated or conflicting complexity labels.
+
+5. **Reporting**
+   - At the top of every output, include a `reportedBy` metadata field:  
+     `reportedBy: <agent-name>.v<major-version>`
+   - Example:  
+     `reportedBy: milestone-complexity-labeler.v1`
+   - Downstream agents must validate the presence and correctness of this field.
+
+6. **References**
+   - For label usage details, refer to [docs/labels-usage.md](../../docs/labels-usage.md).
+
+## Output
+
+- Output all results and plans in clear, structured Markdown.
+- Use English for all output.
+- Always confirm with the user before making changes to issue labels.
+
+---
+
+_Reference: [copilot-customization.instructions.md](../instructions/copilot/copilot-customization.instructions.md)_

--- a/src/shared/utils/removeDiacritics.test.ts
+++ b/src/shared/utils/removeDiacritics.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { removeDiacritics } from '~/shared/utils/removeDiacritics'
+
+describe('removeDiacritics', () => {
+  it('removes accents from common pt-BR words', () => {
+    expect(removeDiacritics('Tapioca doce')).toBe('Tapioca doce')
+    expect(removeDiacritics('Tapioca doçe')).toBe('Tapioca doce')
+    expect(removeDiacritics('Café com açúcar')).toBe('Cafe com acucar')
+    expect(removeDiacritics('Pão de queijo')).toBe('Pao de queijo')
+    expect(removeDiacritics('Fruta maçã')).toBe('Fruta maca')
+  })
+  it('returns empty string for empty input', () => {
+    expect(removeDiacritics('')).toBe('')
+  })
+  it('does not change non-accented input', () => {
+    expect(removeDiacritics('banana')).toBe('banana')
+  })
+})

--- a/src/shared/utils/removeDiacritics.ts
+++ b/src/shared/utils/removeDiacritics.ts
@@ -1,0 +1,5 @@
+// Removes diacritics from a string (e.g., accents)
+// Example: "Tapioca doce" and "Tapioca doçe" both become "Tapioca doce"
+export function removeDiacritics(str: string): string {
+  return str.normalize('NFD').replace(/\p{Diacritic}/gu, '')
+}


### PR DESCRIPTION
This PR enhances the food search functionality to address issues where searches for multi-word or diacritic-containing food names (e.g., "Tapioca doce") returned no results. The main changes are:

- Food search is now diacritic-insensitive, ensuring queries match regardless of accents or special characters.
- Implements a composed search: first returns exact matches for the full query, then includes partial matches for each word in the query, removing duplicates.
- Adds a `removeDiacritics` utility and corresponding tests to support normalization.
- Updates the repository logic to use the new composed and normalized search.
- Refactors and tests the search logic for robustness.

No breaking changes.  
closes #745