### PR TITLE
Add backend outage detection and notification banner

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -4,6 +4,7 @@ import { Router } from '@solidjs/router'
 import { FileRoutes } from '@solidjs/start/router'
 import { createSignal, onCleanup, Suspense } from 'solid-js'
 
+import { BackendOutageBanner } from '~/sections/common/components/BackendOutageBanner'
 import { BottomNavigation } from '~/sections/common/components/BottomNavigation'
 import { Providers } from '~/sections/common/context/Providers'
 
@@ -33,6 +34,7 @@ export default function App() {
         <>
           <Suspense>
             <Providers>
+              <BackendOutageBanner />
               <div
                 class="mx-auto flex flex-col justify-between bg-black h-screen w-screen rounded-none"
                 style={{ width: `${width()}px` }}

--- a/src/modules/diet/food/application/food.ts
+++ b/src/modules/diet/food/application/food.ts
@@ -7,7 +7,11 @@ import {
 import { createSupabaseFoodRepository } from '~/modules/diet/food/infrastructure/supabaseFoodRepository'
 import { isSearchCached } from '~/modules/search/application/searchCache'
 import { showPromise } from '~/modules/toast/application/toastManager'
-import { handleApiError } from '~/shared/error/errorHandler'
+import { setBackendOutage } from '~/shared/error/backendOutageSignal'
+import {
+  handleApiError,
+  isBackendOutageError,
+} from '~/shared/error/errorHandler'
 import { formatError } from '~/shared/formatError'
 
 const foodRepository = createSupabaseFoodRepository()
@@ -28,6 +32,7 @@ export async function fetchFoods(
       operation: 'fetchFoods',
       additionalData: { params },
     })
+    if (isBackendOutageError(error)) setBackendOutage(true)
     return []
   }
 }
@@ -50,6 +55,7 @@ export async function fetchFoodById(
       operation: 'fetchFoodById',
       additionalData: { id, params },
     })
+    if (isBackendOutageError(error)) setBackendOutage(true)
     return null
   }
 }
@@ -92,6 +98,7 @@ export async function fetchFoodsByName(
       operation: 'fetchFoodsByName',
       additionalData: { name, params },
     })
+    if (isBackendOutageError(error)) setBackendOutage(true)
     return []
   }
 }
@@ -103,8 +110,8 @@ export async function fetchFoodsByName(
  * @returns Food or null on error.
  */
 export async function fetchFoodByEan(
-  ean: string,
-  params: Omit<FoodSearchParams, 'limit'> = {},
+  ean: Food['ean'],
+  params: FoodSearchParams = {},
 ): Promise<Food | null> {
   try {
     await showPromise(
@@ -132,6 +139,7 @@ export async function fetchFoodByEan(
       operation: 'fetchFoodByEan',
       additionalData: { ean, params },
     })
+    if (isBackendOutageError(error)) setBackendOutage(true)
     return null
   }
 }
@@ -153,6 +161,7 @@ export async function isEanCached(
       operation: 'isEanCached',
       additionalData: { ean },
     })
+    if (isBackendOutageError(error)) setBackendOutage(true)
     return false
   }
 }

--- a/src/modules/diet/food/infrastructure/api/application/apiFood.ts
+++ b/src/modules/diet/food/infrastructure/api/application/apiFood.ts
@@ -32,8 +32,17 @@ export function convertApi2Food(food: ApiFood): NewFood {
 }
 
 export async function importFoodFromApiByEan(
-  ean: string,
+  ean: Food['ean'],
 ): Promise<Food | null> {
+  if (ean === null) {
+    handleApiError(new Error('EAN is required to import food from API'), {
+      component: 'apiFood',
+      operation: 'importFoodFromApiByEan',
+      additionalData: { ean },
+    })
+    return null
+  }
+
   const apiFood = (await axios.get(`/api/food/ean/${ean}`))
     .data as unknown as ApiFood
 

--- a/src/modules/toast/application/toastManager.ts
+++ b/src/modules/toast/application/toastManager.ts
@@ -17,6 +17,8 @@ import {
   TOAST_DURATION_INFINITY,
   ToastOptions,
 } from '~/modules/toast/domain/toastTypes'
+import { setBackendOutage } from '~/shared/error/backendOutageSignal'
+import { isBackendOutageError } from '~/shared/error/errorHandler'
 import { createDebug } from '~/shared/utils/createDebug'
 import { isNonEmptyString } from '~/shared/utils/isNonEmptyString'
 
@@ -118,6 +120,22 @@ export function showError(
   providedOptions?: Omit<Partial<ToastOptions>, 'type'>,
   providedDisplayMessage?: string,
 ): string {
+  if (isBackendOutageError(error)) {
+    setBackendOutage(true)
+    // Show a custom outage toast (pt-BR):
+    return show(
+      'Falha de conexão com o servidor. Algumas funções podem estar indisponíveis.',
+      {
+        ...mergeToastOptions({
+          ...providedOptions,
+          type: 'error',
+          context: 'background',
+          audience: 'user',
+        }),
+        duration: 8000,
+      },
+    )
+  }
   const options = mergeToastOptions({ ...providedOptions, type: 'error' })
 
   // Pass the original error object to preserve stack/context

--- a/src/sections/common/components/BackendOutageBanner.tsx
+++ b/src/sections/common/components/BackendOutageBanner.tsx
@@ -1,0 +1,19 @@
+import { Show } from 'solid-js'
+
+import { backendOutage } from '~/shared/error/backendOutageSignal'
+
+export function BackendOutageBanner() {
+  return (
+    <Show when={backendOutage()}>
+      <div class="w-full bg-red-700 text-white text-center py-2 z-50 fixed top-0 left-0 shadow-lg">
+        Falha de conexão com o servidor. Algumas funções podem estar
+        indisponíveis.
+        <a href="https://status.supabase.com/">
+          <span class="text-blue-300 hover:underline ml-2">
+            Ver status do Supabase
+          </span>
+        </a>
+      </div>
+    </Show>
+  )
+}

--- a/src/shared/error/backendOutageSignal.ts
+++ b/src/shared/error/backendOutageSignal.ts
@@ -1,0 +1,5 @@
+import { createSignal } from 'solid-js'
+
+const [backendOutage, setBackendOutage] = createSignal(false)
+
+export { backendOutage, setBackendOutage }

--- a/src/shared/error/errorHandler.ts
+++ b/src/shared/error/errorHandler.ts
@@ -119,3 +119,43 @@ export function handleValidationError(
 ): void {
   logError(error, { ...context, operation: 'Validation' })
 }
+
+/**
+ * Detects if an error is a backend outage/network error (e.g., fetch failed, CORS, DNS, etc).
+ * @param error - The error to check
+ * @returns True if the error is a backend outage/network error
+ */
+export function isBackendOutageError(error: unknown): boolean {
+  if (typeof error === 'string') {
+    return (
+      error.includes('Failed to fetch') ||
+      error.includes('NetworkError') ||
+      error.includes('CORS') ||
+      error.includes('net::ERR') ||
+      error.includes('Network request failed')
+    )
+  }
+  if (typeof error === 'object' && error !== null) {
+    const msg =
+      typeof (error as { message?: unknown }).message === 'string'
+        ? (error as { message: string }).message
+        : ''
+    const details =
+      typeof (error as { details?: unknown }).details === 'string'
+        ? (error as { details: string }).details
+        : ''
+    return (
+      msg.includes('Failed to fetch') ||
+      msg.includes('NetworkError') ||
+      msg.includes('CORS') ||
+      msg.includes('net::ERR') ||
+      msg.includes('Network request failed') ||
+      details.includes('Failed to fetch') ||
+      details.includes('NetworkError') ||
+      details.includes('CORS') ||
+      details.includes('net::ERR') ||
+      details.includes('Network request failed')
+    )
+  }
+  return false
+}


### PR DESCRIPTION
This PR introduces backend outage detection and a persistent banner for network errors.

- Adds a backend outage signal and detection logic in the error handler.
- Displays a persistent banner and toast notification when a backend or network outage is detected.
- Updates the food application and toast manager to trigger the outage state.
- Integrates a new `BackendOutageBanner` component into the app layout.
- Improves user awareness of backend/network issues for better UX.

No breaking changes.

closes #752