### PR TITLE
Fix single click to open ItemEditModal in ItemGroupEditModal

### DIFF
--- a/src/sections/item-group/components/ItemGroupEditModalBody.tsx
+++ b/src/sections/item-group/components/ItemGroupEditModalBody.tsx
@@ -1,4 +1,4 @@
-import { type Accessor, type Setter, Show } from 'solid-js'
+import { type Accessor, batch, type Setter, Show } from 'solid-js'
 
 import { type Item } from '~/modules/diet/item/domain/item'
 import { type Recipe } from '~/modules/diet/recipe/domain/recipe'
@@ -41,8 +41,10 @@ export function ItemGroupEditModalBody(props: {
       )
       return
     }
-    props.setEditSelection({ item })
-    props.setItemEditModalVisible(true)
+    batch(() => {
+      props.setEditSelection({ item })
+      props.setItemEditModalVisible(true)
+    })
   }
 
   return (


### PR DESCRIPTION
This pull request fixes a bug where the `ItemEditModal` inside `ItemGroupEditModal` required a double click to open, instead of opening on a single click as expected.

**What was changed:**
- Refactored the item click handler in `ItemGroupEditModalBody.tsx` to use Solid's `batch` function, ensuring that both `editSelection` and `itemEditModalVisible` are updated together.
- This prevents stale state and guarantees the modal opens immediately on the first click.
- All code and comments remain in English, following project conventions.
- All tests and checks pass.

**Motivation:**
- Improves user experience by making item editing more intuitive and responsive.
- Resolves a low-complexity UI bug affecting workflow efficiency.

**Implementation details:**
- No breaking changes.
- No changes to API or data structures.
- No documentation changes.

closes #741