### PR TITLE
Rename Measure to BodyMeasure throughout the codebase

### DIFF
--- a/src/modules/measure/application/measure.ts
+++ b/src/modules/measure/application/measure.ts
@@ -1,25 +1,28 @@
-import { type Measure, type NewMeasure } from '~/modules/measure/domain/measure'
-import { createSupabaseMeasureRepository } from '~/modules/measure/infrastructure/measures'
+import {
+  type BodyMeasure,
+  type NewBodyMeasure,
+} from '~/modules/measure/domain/measure'
+import { createSupabaseBodyMeasureRepository } from '~/modules/measure/infrastructure/measures'
 import { showPromise } from '~/modules/toast/application/toastManager'
 import { type User } from '~/modules/user/domain/user'
 import { handleApiError } from '~/shared/error/errorHandler'
 
-const measureRepository = createSupabaseMeasureRepository()
+const bodyMeasureRepository = createSupabaseBodyMeasureRepository()
 
 /**
- * Fetches all measures for a user.
+ * Fetches all body measures for a user.
  * @param userId - The user ID.
- * @returns Array of measures or empty array on error.
+ * @returns Array of body measures or empty array on error.
  */
-export async function fetchUserMeasures(
+export async function fetchUserBodyMeasures(
   userId: User['id'],
-): Promise<readonly Measure[]> {
+): Promise<readonly BodyMeasure[]> {
   try {
-    return await measureRepository.fetchUserMeasures(userId)
+    return await bodyMeasureRepository.fetchUserBodyMeasures(userId)
   } catch (error) {
     handleApiError(error, {
-      component: 'measureApplication',
-      operation: 'fetchUserMeasures',
+      component: 'bodyMeasureApplication',
+      operation: 'fetchUserBodyMeasures',
       additionalData: { userId },
     })
     return []
@@ -27,16 +30,16 @@ export async function fetchUserMeasures(
 }
 
 /**
- * Inserts a new measure.
- * @param newMeasure - The new measure data.
- * @returns The inserted measure or null on error.
+ * Inserts a new body measure.
+ * @param newBodyMeasure - The new body measure data.
+ * @returns The inserted body measure or null on error.
  */
-export async function insertMeasure(
-  newMeasure: NewMeasure,
-): Promise<Measure | null> {
+export async function insertBodyMeasure(
+  newBodyMeasure: NewBodyMeasure,
+): Promise<BodyMeasure | null> {
   try {
     return await showPromise(
-      measureRepository.insertMeasure(newMeasure),
+      bodyMeasureRepository.insertBodyMeasure(newBodyMeasure),
       {
         loading: 'Inserindo medidas...',
         success: 'Medidas inseridas com sucesso',
@@ -46,27 +49,27 @@ export async function insertMeasure(
     )
   } catch (error) {
     handleApiError(error, {
-      component: 'measureApplication',
-      operation: 'insertMeasure',
-      additionalData: { newMeasure },
+      component: 'bodyMeasureApplication',
+      operation: 'insertBodyMeasure',
+      additionalData: { newBodyMeasure },
     })
     return null
   }
 }
 
 /**
- * Updates a measure by ID.
- * @param measureId - The measure ID.
- * @param newMeasure - The new measure data.
- * @returns The updated measure or null on error.
+ * Updates a body measure by ID.
+ * @param bodyMeasureId - The body measure ID.
+ * @param newBodyMeasure - The new body measure data.
+ * @returns The updated body measure or null on error.
  */
-export async function updateMeasure(
-  measureId: Measure['id'],
-  newMeasure: NewMeasure,
-): Promise<Measure | null> {
+export async function updateBodyMeasure(
+  bodyMeasureId: BodyMeasure['id'],
+  newBodyMeasure: NewBodyMeasure,
+): Promise<BodyMeasure | null> {
   try {
     return await showPromise(
-      measureRepository.updateMeasure(measureId, newMeasure),
+      bodyMeasureRepository.updateBodyMeasure(bodyMeasureId, newBodyMeasure),
       {
         loading: 'Atualizando medidas...',
         success: 'Medidas atualizadas com sucesso',
@@ -76,25 +79,25 @@ export async function updateMeasure(
     )
   } catch (error) {
     handleApiError(error, {
-      component: 'measureApplication',
-      operation: 'updateMeasure',
-      additionalData: { measureId, newMeasure },
+      component: 'bodyMeasureApplication',
+      operation: 'updateBodyMeasure',
+      additionalData: { bodyMeasureId, newBodyMeasure },
     })
     return null
   }
 }
 
 /**
- * Deletes a measure by ID.
- * @param measureId - The measure ID.
+ * Deletes a body measure by ID.
+ * @param bodyMeasureId - The body measure ID.
  * @returns True if deleted, false otherwise.
  */
-export async function deleteMeasure(
-  measureId: Measure['id'],
+export async function deleteBodyMeasure(
+  bodyMeasureId: BodyMeasure['id'],
 ): Promise<boolean> {
   try {
     await showPromise(
-      measureRepository.deleteMeasure(measureId),
+      bodyMeasureRepository.deleteBodyMeasure(bodyMeasureId),
       {
         loading: 'Deletando medidas...',
         success: 'Medidas deletadas com sucesso',
@@ -105,9 +108,9 @@ export async function deleteMeasure(
     return true
   } catch (error) {
     handleApiError(error, {
-      component: 'measureApplication',
-      operation: 'deleteMeasure',
-      additionalData: { measureId },
+      component: 'bodyMeasureApplication',
+      operation: 'deleteBodyMeasure',
+      additionalData: { bodyMeasureId },
     })
     return false
   }

--- a/src/modules/measure/domain/measure.ts
+++ b/src/modules/measure/domain/measure.ts
@@ -2,46 +2,52 @@ import { z } from 'zod'
 
 import { parseWithStack } from '~/shared/utils/parseWithStack'
 
-// TODO:   Create discriminate union type for Male and Female measures
-export const measureSchema = z.object({
+// TODO:   Create discriminate union type for Male and Female body measures
+export const bodyMeasureSchema = z.object({
   id: z.number({
-    required_error: "O campo 'id' da medida é obrigatório.",
-    invalid_type_error: "O campo 'id' da medida deve ser um número.",
+    required_error: "O campo 'id' da medida corporal é obrigatório.",
+    invalid_type_error: "O campo 'id' da medida corporal deve ser um número.",
   }),
   height: z.number({
-    required_error: "O campo 'height' da medida é obrigatório.",
-    invalid_type_error: "O campo 'height' da medida deve ser um número.",
+    required_error: "O campo 'height' da medida corporal é obrigatório.",
+    invalid_type_error:
+      "O campo 'height' da medida corporal deve ser um número.",
   }),
   waist: z.number({
-    required_error: "O campo 'waist' da medida é obrigatório.",
-    invalid_type_error: "O campo 'waist' da medida deve ser um número.",
+    required_error: "O campo 'waist' da medida corporal é obrigatório.",
+    invalid_type_error:
+      "O campo 'waist' da medida corporal deve ser um número.",
   }),
   hip: z
     .number({
-      required_error: "O campo 'hip' da medida é obrigatório.",
-      invalid_type_error: "O campo 'hip' da medida deve ser um número.",
+      required_error: "O campo 'hip' da medida corporal é obrigatório.",
+      invalid_type_error:
+        "O campo 'hip' da medida corporal deve ser um número.",
     })
     .nullish()
     .transform((v) => (v === null ? undefined : v)),
   neck: z.number({
-    required_error: "O campo 'neck' da medida é obrigatório.",
-    invalid_type_error: "O campo 'neck' da medida deve ser um número.",
+    required_error: "O campo 'neck' da medida corporal é obrigatório.",
+    invalid_type_error: "O campo 'neck' da medida corporal deve ser um número.",
   }),
   owner: z.number({
-    required_error: "O campo 'owner' da medida é obrigatório.",
-    invalid_type_error: "O campo 'owner' da medida deve ser um número.",
+    required_error: "O campo 'owner' da medida corporal é obrigatório.",
+    invalid_type_error:
+      "O campo 'owner' da medida corporal deve ser um número.",
   }),
   target_timestamp: z
     .date({
-      required_error: "O campo 'target_timestamp' da medida é obrigatório.",
+      required_error:
+        "O campo 'target_timestamp' da medida corporal é obrigatório.",
       invalid_type_error:
-        "O campo 'target_timestamp' da medida deve ser uma data ou string.",
+        "O campo 'target_timestamp' da medida corporal deve ser uma data ou string.",
     })
     .or(
       z.string({
-        required_error: "O campo 'target_timestamp' da medida é obrigatório.",
+        required_error:
+          "O campo 'target_timestamp' da medida corporal é obrigatório.",
         invalid_type_error:
-          "O campo 'target_timestamp' da medida deve ser uma data ou string.",
+          "O campo 'target_timestamp' da medida corporal deve ser uma data ou string.",
       }),
     )
     .transform((v) => new Date(v)),
@@ -49,20 +55,19 @@ export const measureSchema = z.object({
     .string()
     .nullable()
     .optional()
-    .transform(() => 'Measure' as const),
+    .transform(() => 'BodyMeasure' as const),
 })
 
-export const newMeasureSchema = measureSchema
+export const newBodyMeasureSchema = bodyMeasureSchema
   .omit({ id: true, __type: true })
   .extend({
-    __type: z.literal('NewMeasure'),
+    __type: z.literal('NewBodyMeasure'),
   })
 
-// TODO:   rename to BodyMeasure
-export type Measure = Readonly<z.infer<typeof measureSchema>>
-export type NewMeasure = Readonly<z.infer<typeof newMeasureSchema>>
+export type BodyMeasure = Readonly<z.infer<typeof bodyMeasureSchema>>
+export type NewBodyMeasure = Readonly<z.infer<typeof newBodyMeasureSchema>>
 
-export function createNewMeasure({
+export function createNewBodyMeasure({
   owner,
   height,
   waist,
@@ -76,37 +81,42 @@ export function createNewMeasure({
   hip?: number | null | undefined
   neck: number
   targetTimestamp: Date | string
-}): NewMeasure {
-  return parseWithStack(newMeasureSchema, {
+}): NewBodyMeasure {
+  return parseWithStack(newBodyMeasureSchema, {
     owner,
     height,
     waist,
     hip,
     neck,
     target_timestamp: targetTimestamp,
-    __type: 'NewMeasure',
+    __type: 'NewBodyMeasure',
   })
 }
 
-export function promoteToMeasure(newMeasure: NewMeasure, id: number): Measure {
-  return parseWithStack(measureSchema, {
-    ...newMeasure,
+export function promoteToBodyMeasure(
+  newBodyMeasure: NewBodyMeasure,
+  id: number,
+): BodyMeasure {
+  return parseWithStack(bodyMeasureSchema, {
+    ...newBodyMeasure,
     id,
   })
 }
 
 /**
- * Demotes a Measure to a NewMeasure for updates.
- * Used when converting a persisted Measure back to NewMeasure for database operations.
+ * Demotes a BodyMeasure to a NewBodyMeasure for updates.
+ * Used when converting a persisted BodyMeasure back to NewBodyMeasure for database operations.
  */
-export function demoteToNewMeasure(measure: Measure): NewMeasure {
-  return parseWithStack(newMeasureSchema, {
-    height: measure.height,
-    waist: measure.waist,
-    hip: measure.hip,
-    neck: measure.neck,
-    owner: measure.owner,
-    target_timestamp: measure.target_timestamp,
-    __type: 'NewMeasure',
+export function demoteToNewBodyMeasure(
+  bodyMeasure: BodyMeasure,
+): NewBodyMeasure {
+  return parseWithStack(newBodyMeasureSchema, {
+    height: bodyMeasure.height,
+    waist: bodyMeasure.waist,
+    hip: bodyMeasure.hip,
+    neck: bodyMeasure.neck,
+    owner: bodyMeasure.owner,
+    target_timestamp: bodyMeasure.target_timestamp,
+    __type: 'NewBodyMeasure',
   })
 }

--- a/src/modules/measure/domain/measureRepository.ts
+++ b/src/modules/measure/domain/measureRepository.ts
@@ -1,12 +1,17 @@
-import { type Measure, type NewMeasure } from '~/modules/measure/domain/measure'
+import {
+  type BodyMeasure,
+  type NewBodyMeasure,
+} from '~/modules/measure/domain/measure'
 import { type User } from '~/modules/user/domain/user'
 
-export type MeasureRepository = {
-  fetchUserMeasures: (userId: User['id']) => Promise<readonly Measure[]>
-  insertMeasure: (newMeasure: NewMeasure) => Promise<Measure | null>
-  updateMeasure: (
-    measureId: Measure['id'],
-    newMeasure: NewMeasure,
-  ) => Promise<Measure | null>
-  deleteMeasure: (id: Measure['id']) => Promise<void>
+export type BodyMeasureRepository = {
+  fetchUserBodyMeasures: (userId: User['id']) => Promise<readonly BodyMeasure[]>
+  insertBodyMeasure: (
+    newBodyMeasure: NewBodyMeasure,
+  ) => Promise<BodyMeasure | null>
+  updateBodyMeasure: (
+    bodyMeasureId: BodyMeasure['id'],
+    newBodyMeasure: NewBodyMeasure,
+  ) => Promise<BodyMeasure | null>
+  deleteBodyMeasure: (id: BodyMeasure['id']) => Promise<void>
 }

--- a/src/modules/measure/infrastructure/measureDAO.ts
+++ b/src/modules/measure/infrastructure/measureDAO.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod'
 
 import {
-  type Measure,
-  measureSchema,
-  type NewMeasure,
+  type BodyMeasure,
+  bodyMeasureSchema,
+  type NewBodyMeasure,
 } from '~/modules/measure/domain/measure'
 import { parseWithStack } from '~/shared/utils/parseWithStack'
 
 // DAO schemas for database operations
-export const createMeasureDAOSchema = z.object({
+export const createBodyMeasureDAOSchema = z.object({
   height: z.number(),
   waist: z.number(),
   hip: z.number().nullish(),
@@ -17,35 +17,35 @@ export const createMeasureDAOSchema = z.object({
   target_timestamp: z.date().or(z.string()),
 })
 
-export const measureDAOSchema = createMeasureDAOSchema.extend({
+export const bodyMeasureDAOSchema = createBodyMeasureDAOSchema.extend({
   id: z.number(),
 })
 
-export type CreateMeasureDAO = z.infer<typeof createMeasureDAOSchema>
-export type MeasureDAO = z.infer<typeof measureDAOSchema>
+export type CreateBodyMeasureDAO = z.infer<typeof createBodyMeasureDAOSchema>
+export type BodyMeasureDAO = z.infer<typeof bodyMeasureDAOSchema>
 
 // Conversion functions
-export function createInsertMeasureDAOFromNewMeasure(
-  newMeasure: NewMeasure,
-): CreateMeasureDAO {
+export function createInsertBodyMeasureDAOFromNewBodyMeasure(
+  newBodyMeasure: NewBodyMeasure,
+): CreateBodyMeasureDAO {
   return {
-    height: newMeasure.height,
-    waist: newMeasure.waist,
-    hip: newMeasure.hip,
-    neck: newMeasure.neck,
-    owner: newMeasure.owner,
-    target_timestamp: newMeasure.target_timestamp,
+    height: newBodyMeasure.height,
+    waist: newBodyMeasure.waist,
+    hip: newBodyMeasure.hip,
+    neck: newBodyMeasure.neck,
+    owner: newBodyMeasure.owner,
+    target_timestamp: newBodyMeasure.target_timestamp,
   }
 }
 
-export function createUpdateMeasureDAOFromNewMeasure(
-  newMeasure: NewMeasure,
-): CreateMeasureDAO {
-  return createInsertMeasureDAOFromNewMeasure(newMeasure)
+export function createUpdateBodyMeasureDAOFromNewBodyMeasure(
+  newBodyMeasure: NewBodyMeasure,
+): CreateBodyMeasureDAO {
+  return createInsertBodyMeasureDAOFromNewBodyMeasure(newBodyMeasure)
 }
 
-export function createMeasureFromDAO(dao: MeasureDAO): Measure {
-  return parseWithStack(measureSchema, {
+export function createBodyMeasureFromDAO(dao: BodyMeasureDAO): BodyMeasure {
+  return parseWithStack(bodyMeasureSchema, {
     id: dao.id,
     height: dao.height,
     waist: dao.waist,

--- a/src/modules/measure/infrastructure/measures.ts
+++ b/src/modules/measure/infrastructure/measures.ts
@@ -1,10 +1,13 @@
-import { type Measure, type NewMeasure } from '~/modules/measure/domain/measure'
-import { type MeasureRepository } from '~/modules/measure/domain/measureRepository'
 import {
-  createInsertMeasureDAOFromNewMeasure,
-  createMeasureFromDAO,
-  createUpdateMeasureDAOFromNewMeasure,
-  measureDAOSchema,
+  type BodyMeasure,
+  type NewBodyMeasure,
+} from '~/modules/measure/domain/measure'
+import { type BodyMeasureRepository } from '~/modules/measure/domain/measureRepository'
+import {
+  bodyMeasureDAOSchema,
+  createBodyMeasureFromDAO,
+  createInsertBodyMeasureDAOFromNewBodyMeasure,
+  createUpdateBodyMeasureDAOFromNewBodyMeasure,
 } from '~/modules/measure/infrastructure/measureDAO'
 import { type User } from '~/modules/user/domain/user'
 import { handleApiError, wrapErrorWithStack } from '~/shared/error/errorHandler'
@@ -13,16 +16,16 @@ import supabase from '~/shared/utils/supabase'
 
 const TABLE = 'body_measures'
 
-export function createSupabaseMeasureRepository(): MeasureRepository {
+export function createSupabaseBodyMeasureRepository(): BodyMeasureRepository {
   return {
-    fetchUserMeasures,
-    insertMeasure,
-    updateMeasure,
-    deleteMeasure,
+    fetchUserBodyMeasures,
+    insertBodyMeasure,
+    updateBodyMeasure,
+    deleteBodyMeasure,
   }
 }
 
-async function fetchUserMeasures(userId: User['id']) {
+async function fetchUserBodyMeasures(userId: User['id']) {
   const { data, error } = await supabase
     .from(TABLE)
     .select('*')
@@ -31,69 +34,71 @@ async function fetchUserMeasures(userId: User['id']) {
 
   if (error !== null) {
     handleApiError(error, {
-      component: 'supabaseMeasureRepository',
-      operation: 'fetchUserMeasures',
+      component: 'supabaseBodyMeasureRepository',
+      operation: 'fetchUserBodyMeasures',
       additionalData: { userId },
     })
     throw wrapErrorWithStack(error)
   }
 
-  const measureDAOs = parseWithStack(measureDAOSchema.array(), data)
-  return measureDAOs.map(createMeasureFromDAO)
+  const bodyMeasureDAOs = parseWithStack(bodyMeasureDAOSchema.array(), data)
+  return bodyMeasureDAOs.map(createBodyMeasureFromDAO)
 }
 
-async function insertMeasure(newMeasure: NewMeasure): Promise<Measure | null> {
-  const createDAO = createInsertMeasureDAOFromNewMeasure(newMeasure)
+async function insertBodyMeasure(
+  newBodyMeasure: NewBodyMeasure,
+): Promise<BodyMeasure | null> {
+  const createDAO = createInsertBodyMeasureDAOFromNewBodyMeasure(newBodyMeasure)
   const { data, error } = await supabase.from(TABLE).insert(createDAO).select()
 
   if (error !== null) {
     handleApiError(error, {
-      component: 'supabaseMeasureRepository',
-      operation: 'insertMeasure',
-      additionalData: { measure: newMeasure },
+      component: 'supabaseBodyMeasureRepository',
+      operation: 'insertBodyMeasure',
+      additionalData: { bodyMeasure: newBodyMeasure },
     })
     throw wrapErrorWithStack(error)
   }
 
-  const measureDAOs = parseWithStack(measureDAOSchema.array(), data)
-  const measures = measureDAOs.map(createMeasureFromDAO)
+  const bodyMeasureDAOs = parseWithStack(bodyMeasureDAOSchema.array(), data)
+  const bodyMeasures = bodyMeasureDAOs.map(createBodyMeasureFromDAO)
 
-  return measures[0] ?? null
+  return bodyMeasures[0] ?? null
 }
 
-async function updateMeasure(
-  measureId: Measure['id'],
-  newMeasure: NewMeasure,
-): Promise<Measure | null> {
-  const updateDAO = createUpdateMeasureDAOFromNewMeasure(newMeasure)
+async function updateBodyMeasure(
+  bodyMeasureId: BodyMeasure['id'],
+  newBodyMeasure: NewBodyMeasure,
+): Promise<BodyMeasure | null> {
+  const updateDAO = createUpdateBodyMeasureDAOFromNewBodyMeasure(newBodyMeasure)
   const { data, error } = await supabase
     .from(TABLE)
     .update(updateDAO)
-    .eq('id', measureId)
+    .eq('id', bodyMeasureId)
     .select()
 
   if (error !== null) {
     handleApiError(error, {
-      component: 'supabaseMeasureRepository',
-      operation: 'updateMeasure',
-      additionalData: { measureId, measure: newMeasure },
+      component: 'supabaseBodyMeasureRepository',
+      operation: 'updateBodyMeasure',
+      additionalData: { bodyMeasureId, bodyMeasure: newBodyMeasure },
     })
     throw wrapErrorWithStack(error)
   }
 
-  const measureDAOs = parseWithStack(measureDAOSchema.array(), data)
-  const measures = measureDAOs.map(createMeasureFromDAO)
+  const bodyMeasureDAOs = parseWithStack(bodyMeasureDAOSchema.array(), data)
+  const bodyMeasures = bodyMeasureDAOs.map(createBodyMeasureFromDAO)
 
-  return measures[0] ?? null
+  return bodyMeasures[0] ?? null
 }
 
-async function deleteMeasure(id: Measure['id']) {
+async function deleteBodyMeasure(id: BodyMeasure['id']) {
   const { error } = await supabase.from(TABLE).delete().eq('id', id)
 
   if (error !== null) {
     handleApiError(error, {
-      component: 'supabaseMeasureRepository',
-      operation: 'deleteMeasure',
+      component: 'supabaseBodyMeasureRepository',
+      operation: 'deleteBodyMeasure',
       additionalData: { id },
     })
     throw wrapErrorWithStack(error)

--- a/src/sections/profile/measure/components/MeasureChart.tsx
+++ b/src/sections/profile/measure/components/MeasureChart.tsx
@@ -3,13 +3,16 @@ import { SolidApexCharts } from 'solid-apexcharts'
 import { createMemo, Show } from 'solid-js'
 
 import ptBrLocale from '~/assets/locales/apex/pt-br.json'
-import { type Measure } from '~/modules/measure/domain/measure'
+import { type BodyMeasure } from '~/modules/measure/domain/measure'
 import { currentUser } from '~/modules/user/application/user'
 import { userWeights } from '~/modules/weight/application/weight'
 import { type BodyFatInput, calculateBodyFat } from '~/shared/utils/bfMath'
 import { dateToYYYYMMDD } from '~/shared/utils/date'
 
-type DayAverage = Omit<Measure, '__type' | 'id' | 'owner' | 'target_timestamp'>
+type DayAverage = Omit<
+  BodyMeasure,
+  '__type' | 'id' | 'owner' | 'target_timestamp'
+>
 type DayMeasures = {
   date: string
   dayAverage: DayAverage
@@ -20,7 +23,7 @@ type DayMeasures = {
  * Props for the MeasureChart component.
  */
 export type MeasureChartProps = {
-  measures: readonly Measure[]
+  measures: readonly BodyMeasure[]
 }
 
 /**
@@ -34,7 +37,7 @@ export function MeasureChart(props: MeasureChartProps) {
     console.debug('[MeasureChart] props.measures', props.measures)
   })
   const measuresByDay = () => {
-    const grouped = props.measures.reduce<Record<string, Measure[]>>(
+    const grouped = props.measures.reduce<Record<string, BodyMeasure[]>>(
       (acc, measure) => {
         const day = dateToYYYYMMDD(measure.target_timestamp)
         if (acc[day] === undefined) {

--- a/src/sections/profile/measure/components/MeasureView.tsx
+++ b/src/sections/profile/measure/components/MeasureView.tsx
@@ -1,10 +1,10 @@
 import {
-  deleteMeasure,
-  updateMeasure,
+  deleteBodyMeasure,
+  updateBodyMeasure,
 } from '~/modules/measure/application/measure'
 import {
-  createNewMeasure,
-  type Measure,
+  type BodyMeasure,
+  createNewBodyMeasure,
 } from '~/modules/measure/domain/measure'
 import { showError } from '~/modules/toast/application/toastManager'
 import { Capsule } from '~/sections/common/components/capsule/Capsule'
@@ -18,13 +18,13 @@ import { formatError } from '~/shared/formatError'
 import { adjustToTimezone } from '~/shared/utils/date/dateUtils'
 
 /**
- * Renders a capsule view for editing and saving a single Measure.
+ * Renders a capsule view for editing and saving a single BodyMeasure.
  *
- * @param props.measure - The measure to display and edit
- * @param props.onRefetchMeasures - Callback to refetch measures after update/delete
+ * @param props.measure - The body measure to display and edit
+ * @param props.onRefetchMeasures - Callback to refetch body measures after update/delete
  */
 export function MeasureView(props: {
-  measure: Measure
+  measure: BodyMeasure
   onRefetchMeasures: () => unknown
 }) {
   const dateField = useDateField(() => props.measure.target_timestamp, {
@@ -61,9 +61,9 @@ export function MeasureView(props: {
     const afterUpdate = () => {
       props.onRefetchMeasures()
     }
-    updateMeasure(
+    updateBodyMeasure(
       props.measure.id,
-      createNewMeasure({
+      createNewBodyMeasure({
         ...props.measure,
         height,
         waist,
@@ -95,7 +95,7 @@ export function MeasureView(props: {
             const afterDelete = () => {
               props.onRefetchMeasures()
             }
-            deleteMeasure(props.measure.id)
+            deleteBodyMeasure(props.measure.id)
               .then(afterDelete)
               .catch((error) => {
                 showError(

--- a/src/sections/profile/measure/components/MeasuresEvolution.tsx
+++ b/src/sections/profile/measure/components/MeasuresEvolution.tsx
@@ -1,10 +1,10 @@
 import { createResource, For, Show } from 'solid-js'
 
 import {
-  fetchUserMeasures,
-  insertMeasure,
+  fetchUserBodyMeasures,
+  insertBodyMeasure,
 } from '~/modules/measure/application/measure'
-import { createNewMeasure } from '~/modules/measure/domain/measure'
+import { createNewBodyMeasure } from '~/modules/measure/domain/measure'
 import { CARD_BACKGROUND_COLOR, CARD_STYLE } from '~/modules/theme/constants'
 import { showError } from '~/modules/toast/application/toastManager'
 import { currentUserId } from '~/modules/user/application/user'
@@ -15,11 +15,11 @@ import { MeasureView } from '~/sections/profile/measure/components/MeasureView'
 import { formatError } from '~/shared/formatError'
 
 export function MeasuresEvolution() {
-  const [measuresResource, { refetch }] = createResource(
+  const [bodyMeasuresResource, { refetch }] = createResource(
     currentUserId,
-    fetchUserMeasures,
+    fetchUserBodyMeasures,
   )
-  const measures = () => measuresResource() ?? []
+  const bodyMeasures = () => bodyMeasuresResource() ?? []
 
   const heightField = useFloatField()
   const waistField = useFloatField()
@@ -92,8 +92,8 @@ export function MeasuresEvolution() {
               }
               const userId = currentUserId()
 
-              insertMeasure(
-                createNewMeasure({
+              insertBodyMeasure(
+                createNewBodyMeasure({
                   owner: userId,
                   height: heightField.value() ?? 0,
                   waist: waistField.value() ?? 0,
@@ -114,21 +114,24 @@ export function MeasuresEvolution() {
         </div>
 
         <Show
-          when={!measuresResource.loading}
+          when={!bodyMeasuresResource.loading}
           fallback={
             <div class="text-center text-gray-400 py-8">
               Carregando medidas...
             </div>
           }
         >
-          <MeasureChart measures={measures()} />
+          <MeasureChart measures={bodyMeasures()} />
           <div class="mx-5 lg:mx-20 pb-10">
-            <For each={[...measures()].reverse().slice(0, 10)}>
-              {(measure) => (
-                <MeasureView measure={measure} onRefetchMeasures={refetch} />
+            <For each={[...bodyMeasures()].reverse().slice(0, 10)}>
+              {(bodyMeasure) => (
+                <MeasureView
+                  measure={bodyMeasure}
+                  onRefetchMeasures={refetch}
+                />
               )}
             </For>
-            {measures().length === 0 && 'Não há pesos registrados'}
+            {bodyMeasures().length === 0 && 'Não há pesos registrados'}
           </div>
         </Show>
       </div>

--- a/src/shared/utils/bfMath.ts
+++ b/src/shared/utils/bfMath.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { type Measure } from '~/modules/measure/domain/measure'
+import { type BodyMeasure } from '~/modules/measure/domain/measure'
 import { type User } from '~/modules/user/domain/user'
 import { type Weight } from '~/modules/weight/domain/weight'
 import { parseWithStack } from '~/shared/utils/parseWithStack'
@@ -8,10 +8,10 @@ import { parseWithStack } from '~/shared/utils/parseWithStack'
 export type BodyFatInput<T extends User['gender']> = {
   gender: T
   weight: Weight['weight']
-  waist: Measure['waist']
-  neck: Measure['neck']
-  hip: T extends 'male' ? Measure['hip'] : NonNullable<Measure['hip']>
-  height: Measure['height']
+  waist: BodyMeasure['waist']
+  neck: BodyMeasure['neck']
+  hip: T extends 'male' ? BodyMeasure['hip'] : NonNullable<BodyMeasure['hip']>
+  height: BodyMeasure['height']
 }
 
 export function calculateBodyFat<T extends User['gender']>(


### PR DESCRIPTION
This pull request refactors the entire codebase to rename the domain type `Measure` and all related code—including types, functions, schemas, variables, and UI components—to `BodyMeasure` for improved clarity and consistency.

**What was changed:**
- Renamed all types, interfaces, schemas, and functions from `Measure`/`NewMeasure` to `BodyMeasure`/`NewBodyMeasure` in the domain, application, infrastructure, and UI layers.
- Updated all import/export statements and references in other modules to use the new naming.
- Refactored all UI components, props, and hooks referencing `Measure` to use `BodyMeasure`.
- Updated all related tests, shared utilities, and documentation to use the new naming.
- Ensured no references to the old name remain in the codebase (except in migration/changelog notes if required).

**Motivation:**
- The previous name `Measure` was too generic and could cause confusion with other measurement concepts.
- Using `BodyMeasure` makes the domain intent explicit, aligns with clean architecture and naming conventions, and improves code readability and maintainability.

**Notable details:**
- All code, comments, and commit messages are in English.
- All lint, type, and test checks pass.
- No breaking changes to the API, but all consumers must now use the new `BodyMeasure` naming.

**References:**
- See `docs/CODESTYLE_GUIDE.md` for naming conventions.
- See `docs/audit_domain_measure.md` for domain audit and rationale.

closes #465