### PR TITLE
Batch fetch foods by IDs for 'recent' tab

### DIFF
--- a/src/modules/diet/food/application/food.ts
+++ b/src/modules/diet/food/application/food.ts
@@ -165,3 +165,24 @@ export async function isEanCached(
     return false
   }
 }
+
+/**
+ * Fetches foods by IDs.
+ * @param ids - Array of food IDs.
+ * @returns Array of foods or empty array on error.
+ */
+export async function fetchFoodsByIds(
+  ids: Food['id'][],
+): Promise<readonly Food[]> {
+  try {
+    return await foodRepository.fetchFoodsByIds(ids)
+  } catch (error) {
+    handleApiError(error, {
+      component: 'foodApplication',
+      operation: 'fetchFoodsByIds',
+      additionalData: { ids },
+    })
+    if (isBackendOutageError(error)) setBackendOutage(true)
+    return []
+  }
+}

--- a/src/modules/diet/food/domain/foodRepository.ts
+++ b/src/modules/diet/food/domain/foodRepository.ts
@@ -6,6 +6,12 @@ export type FoodSearchParams = {
 }
 
 export type FoodRepository = {
+  /**
+   * Fetches foods by an array of IDs.
+   * @param ids - Array of Food IDs.
+   * @returns Array of foods matching the IDs.
+   */
+  fetchFoodsByIds: (ids: Food['id'][]) => Promise<readonly Food[]>
   fetchFoods: (params: FoodSearchParams) => Promise<readonly Food[]>
   fetchFoodById: (
     id: Food['id'],

--- a/src/modules/search/application/search.ts
+++ b/src/modules/search/application/search.ts
@@ -3,6 +3,7 @@ import { createResource, createSignal, untrack } from 'solid-js'
 import {
   fetchFoodById,
   fetchFoods,
+  fetchFoodsByIds,
   fetchFoodsByName,
 } from '~/modules/diet/food/application/food'
 import { Food } from '~/modules/diet/food/domain/food'
@@ -115,27 +116,18 @@ const fetchFoodsForModal = async (): Promise<readonly Food[]> => {
     foods = await fetchFoodsByName(templateSearch(), { limit, allowedFoods })
   }
 
-  if (templateSearchTab() === 'recent') {
-    foods = (
-      await Promise.all(
-        allowedFoods?.map(async (foodId) => {
-          let food: Food | null = null
-          const alreadyFechedFood = foods.find((food) => food.id === foodId)
-          if (alreadyFechedFood === undefined) {
-            console.debug(
-              `[TemplateSearchModal] Food is not already fetched: ${foodId}`,
-            )
-            food = await fetchFoodById(foodId)
-          } else {
-            console.debug(
-              `[TemplateSearchModal] Food is already fetched: ${foodId}`,
-            )
-            food = alreadyFechedFood
-          }
-          return food
-        }) ?? [],
-      )
-    ).filter((food): food is Food => food !== null)
+  // Refactored: For 'recent' tab, ensure all required foods are present by batch fetching any missing ones
+  if (templateSearchTab() === 'recent' && Array.isArray(allowedFoods)) {
+    const fetchedIds = new Set(foods.map((food) => food.id))
+    const missingIds = allowedFoods.filter((id) => !fetchedIds.has(id))
+    if (missingIds.length > 0) {
+      const batchFoods = await fetchFoodsByIds(missingIds)
+      foods = [...foods, ...batchFoods]
+    }
+    // Ensure order matches allowedFoods
+    foods = allowedFoods
+      .map((id) => foods.find((food) => food.id === id))
+      .filter((food): food is Food => food !== undefined)
   }
   return foods
 }


### PR DESCRIPTION
This pull request refactors the search modal logic to batch fetch all foods for the 'recent' tab, improving performance and reducing backend load. It introduces a new `fetchFoodsByIds` method in the food repository, application, and infrastructure layers, enabling efficient retrieval of multiple foods by their IDs in a single query.

**Key changes:**
- Adds `fetchFoodsByIds` to the domain, application, and infrastructure layers for true batch food fetching.
- Updates `fetchFoodsForModal` to use `fetchFoodsByIds` for the 'recent' tab, eliminating legacy per-food fetch logic.
- Improves performance and reliability for users with many recent foods.
- Cleans up and documents the new batch fetch logic.

No breaking changes are introduced. This PR addresses performance and data consumption concerns for the 'recent' tab in the search modal.

closes #766