### PR TITLE
Adjust date handling for measure and weight components

### DIFF
--- a/src/sections/profile/measure/components/MeasureView.tsx
+++ b/src/sections/profile/measure/components/MeasureView.tsx
@@ -15,7 +15,7 @@ import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalCo
 import { useDateField, useFloatField } from '~/sections/common/hooks/useField'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
 import { formatError } from '~/shared/formatError'
-import { adjustToTimezone, getMidnight } from '~/shared/utils/date/dateUtils'
+import { normalizeDateToLocalMidnightPlusOne } from '~/shared/utils/date/normalizeDateToLocalMidnightPlusOne'
 
 /**
  * Renders a capsule view for editing and saving a single Measure.
@@ -123,10 +123,7 @@ export function MeasureView(props: {
                 showError(`Data inválida: ${JSON.stringify(value)}`)
                 return
               }
-              let date = getMidnight(
-                adjustToTimezone(new Date(value.startDate)),
-              )
-              date.setDate(date.getDate() + 1)
+              const date = normalizeDateToLocalMidnightPlusOne(value.startDate)
               dateField.setRawValue(date.toISOString())
               handleSave({
                 date,

--- a/src/sections/profile/measure/components/MeasureView.tsx
+++ b/src/sections/profile/measure/components/MeasureView.tsx
@@ -15,7 +15,7 @@ import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalCo
 import { useDateField, useFloatField } from '~/sections/common/hooks/useField'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
 import { formatError } from '~/shared/formatError'
-import { adjustToTimezone } from '~/shared/utils/date/dateUtils'
+import { adjustToTimezone, getMidnight } from '~/shared/utils/date/dateUtils'
 
 /**
  * Renders a capsule view for editing and saving a single Measure.
@@ -123,7 +123,10 @@ export function MeasureView(props: {
                 showError(`Data inválida: ${JSON.stringify(value)}`)
                 return
               }
-              const date = adjustToTimezone(new Date(value.startDate))
+              let date = getMidnight(
+                adjustToTimezone(new Date(value.startDate)),
+              )
+              date.setDate(date.getDate() + 1)
               dateField.setRawValue(date.toISOString())
               handleSave({
                 date,

--- a/src/sections/weight/components/WeightView.tsx
+++ b/src/sections/weight/components/WeightView.tsx
@@ -8,11 +8,8 @@ import { TrashIcon } from '~/sections/common/components/icons/TrashIcon'
 import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 import { useDateField, useFloatField } from '~/sections/common/hooks/useField'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
-import {
-  adjustToTimezone,
-  dateToYYYYMMDD,
-  getMidnight,
-} from '~/shared/utils/date'
+import { dateToYYYYMMDD } from '~/shared/utils/date'
+import { normalizeDateToLocalMidnightPlusOne } from '~/shared/utils/date/normalizeDateToLocalMidnightPlusOne'
 
 /**
  * Props for the WeightView component.
@@ -67,10 +64,9 @@ export function WeightView(props: WeightViewProps) {
                 showError('Data inválida: \n' + JSON.stringify(value))
                 return
               }
-              let date = getMidnight(
-                adjustToTimezone(new Date(value.startDate as string)),
+              const date = normalizeDateToLocalMidnightPlusOne(
+                value.startDate as string,
               )
-              date.setDate(date.getDate() + 1)
               dateField.setRawValue(dateToYYYYMMDD(date))
               handleSave({ dateValue: date, weightValue: weightField.value() })
             }}

--- a/src/sections/weight/components/WeightView.tsx
+++ b/src/sections/weight/components/WeightView.tsx
@@ -8,7 +8,11 @@ import { TrashIcon } from '~/sections/common/components/icons/TrashIcon'
 import { useConfirmModalContext } from '~/sections/common/context/ConfirmModalContext'
 import { useDateField, useFloatField } from '~/sections/common/hooks/useField'
 import Datepicker from '~/sections/datepicker/components/Datepicker'
-import { adjustToTimezone, dateToYYYYMMDD } from '~/shared/utils/date'
+import {
+  adjustToTimezone,
+  dateToYYYYMMDD,
+  getMidnight,
+} from '~/shared/utils/date'
 
 /**
  * Props for the WeightView component.
@@ -63,7 +67,10 @@ export function WeightView(props: WeightViewProps) {
                 showError('Data inválida: \n' + JSON.stringify(value))
                 return
               }
-              const date = adjustToTimezone(new Date(value.startDate as string))
+              let date = getMidnight(
+                adjustToTimezone(new Date(value.startDate as string)),
+              )
+              date.setDate(date.getDate() + 1)
               dateField.setRawValue(dateToYYYYMMDD(date))
               handleSave({ dateValue: date, weightValue: weightField.value() })
             }}

--- a/src/shared/utils/date/normalizeDateToLocalMidnightPlusOne.ts
+++ b/src/shared/utils/date/normalizeDateToLocalMidnightPlusOne.ts
@@ -1,0 +1,15 @@
+/**
+ * Normalizes a date string or Date object to midnight (00:00) in the local timezone and increments by one day.
+ *
+ * @param {string | Date} input - The date to normalize
+ * @returns {Date} The normalized date at midnight, incremented by one day
+ */
+import { adjustToTimezone, getMidnight } from '~/shared/utils/date'
+
+export function normalizeDateToLocalMidnightPlusOne(
+  input: string | Date,
+): Date {
+  let date = getMidnight(adjustToTimezone(new Date(input)))
+  date.setDate(date.getDate() + 1)
+  return date
+}


### PR DESCRIPTION
This PR fixes the date handling logic for both weight and measure editing flows. Previously, setting the date to midnight could result in the previous day being selected due to timezone adjustments. The new logic ensures that after setting the date to midnight, the day is incremented by one, guaranteeing the correct day is always selected and stored.

**What was changed:**
- In both `WeightView` and `MeasureView`, the date is now set to midnight and then incremented by one day when the user changes the date.
- This prevents off-by-one-day errors caused by timezone conversions.

**Why:**
- To ensure that when users select a date, the correct day is always saved, regardless of timezone or browser behavior.

**Notable details:**
- No breaking changes.
- No changes to API or data structure.
- Only application logic in the date handling was updated.

closes #740