### PR TITLE
Refactor convertApi2Food function to shared utils

### DIFF
--- a/src/modules/diet/food/infrastructure/api/application/apiFood.ts
+++ b/src/modules/diet/food/infrastructure/api/application/apiFood.ts
@@ -1,35 +1,15 @@
 import axios from 'axios'
 
-import {
-  createNewFood,
-  type Food,
-  type NewFood,
-} from '~/modules/diet/food/domain/food'
+import { type Food } from '~/modules/diet/food/domain/food'
 import { type ApiFood } from '~/modules/diet/food/infrastructure/api/domain/apiFoodModel'
 import { createSupabaseFoodRepository } from '~/modules/diet/food/infrastructure/supabaseFoodRepository'
 import { markSearchAsCached } from '~/modules/search/application/searchCache'
 import { showError } from '~/modules/toast/application/toastManager'
 import { handleApiError } from '~/shared/error/errorHandler'
+import { convertApi2Food } from '~/shared/utils/convertApi2Food'
 
 // TODO:   Depency injection for repositories on all application files
 const foodRepository = createSupabaseFoodRepository()
-
-// TODO:   Move `convertApi2Food` to a more appropriate place
-export function convertApi2Food(food: ApiFood): NewFood {
-  return createNewFood({
-    name: food.nome,
-    source: {
-      type: 'api',
-      id: food.id.toString(),
-    },
-    ean: food.ean === '' ? null : food.ean, // Convert EAN to null if not provided
-    macros: {
-      carbs: food.carboidratos * 100,
-      protein: food.proteinas * 100,
-      fat: food.gordura * 100,
-    },
-  })
-}
 
 export async function importFoodFromApiByEan(
   ean: Food['ean'],
@@ -100,12 +80,6 @@ export async function importFoodsFromApiByName(name: string): Promise<Food[]> {
     )
 
     if (relevantErrors.length > 0) {
-      const errorDetails = {
-        rejectedCount: relevantErrors.length,
-        errors: relevantErrors,
-        searchName: name,
-      }
-
       handleApiError(
         new Error(`Failed to upsert ${relevantErrors.length} foods`),
       )

--- a/src/shared/utils/convertApi2Food.ts
+++ b/src/shared/utils/convertApi2Food.ts
@@ -1,0 +1,23 @@
+import { createNewFood, type NewFood } from '~/modules/diet/food/domain/food'
+import { type ApiFood } from '~/modules/diet/food/infrastructure/api/domain/apiFoodModel'
+
+/**
+ * Converts an ApiFood object to a NewFood object.
+ * @param food - The ApiFood object to convert.
+ * @returns The corresponding NewFood object.
+ */
+export function convertApi2Food(food: ApiFood): NewFood {
+  return createNewFood({
+    name: food.nome,
+    source: {
+      type: 'api',
+      id: food.id.toString(),
+    },
+    ean: food.ean === '' ? null : food.ean, // Convert EAN to null if not provided
+    macros: {
+      carbs: food.carboidratos * 100,
+      protein: food.proteinas * 100,
+      fat: food.gordura * 100,
+    },
+  })
+}


### PR DESCRIPTION
Move the `convertApi2Food` function to a shared utilities module for better organization and reusability. This change enhances code maintainability by centralizing the conversion logic.