### PR TITLE
Show user initial as fallback for profile icon

### DIFF
--- a/src/sections/common/components/BottomNavigation.tsx
+++ b/src/sections/common/components/BottomNavigation.tsx
@@ -117,7 +117,15 @@ export function BottomNavigation() {
             <BottomNavigationTab
               active={false}
               label="Usuário"
-              icon={(props) => <UserIcon userId={currentUserId()} {...props} />}
+              icon={(props) => (
+                <UserIcon
+                  userId={currentUserId}
+                  userName={() =>
+                    users().find((u) => u.id === currentUserId())?.name ?? ''
+                  }
+                  {...props}
+                />
+              )}
               onClick={() => {
                 showConfirmModal({
                   title: '',
@@ -298,7 +306,11 @@ const UserSelectorDropdown = () => {
       body: () => (
         <div class="flex justify-between">
           <span>{`Deseja entrar como ${user.name}?`}</span>
-          <UserIcon class="w-16 h-16" userId={user.id} />
+          <UserIcon
+            class="w-16 h-16"
+            userId={() => user.id}
+            userName={() => user.name}
+          />
         </div>
       ),
       actions: [
@@ -332,7 +344,11 @@ const UserSelectorDropdown = () => {
               dropdown?.blur()
             }}
           >
-            <UserIcon class="w-10 h-10" userId={user.id} />
+            <UserIcon
+              class="w-10 h-10"
+              userId={() => user.id}
+              userName={() => user.name}
+            />
             <div class="text-xl flex-1 text-start">{user.name}</div>
           </div>
         )}

--- a/src/sections/common/components/icons/UserIcon.tsx
+++ b/src/sections/common/components/icons/UserIcon.tsx
@@ -1,17 +1,32 @@
-import { type User } from '~/modules/user/domain/user'
+import { Accessor, createSignal, Show } from 'solid-js'
 
-export function UserIcon(props: { userId: User['id']; class?: string }) {
-  // TODO:   validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
+import { type User } from '~/modules/user/domain/user'
+import { UserInitialFallback } from '~/sections/common/components/icons/UserInitialFallback'
+
+export function UserIcon(props: {
+  userId: Accessor<User['id']>
+  userName: Accessor<string>
+  class?: string
+}) {
+  const [errored, setErrored] = createSignal(false)
   return (
     <div class={props.class}>
-      <img
-        class="w-full h-full rounded-full"
-        src={`https://sbhhxgeaflzmzpmatnir.supabase.co/storage/v1/object/public/uploads/${props.userId}.jpg`}
-        sizes="100vw"
-        alt=""
-        width={0}
-        height={0}
-      />
+      <Show
+        when={!errored()}
+        fallback={
+          <UserInitialFallback name={props.userName()} class="w-full h-full" />
+        }
+      >
+        <img
+          class="w-full h-full rounded-full"
+          src={`https://sbhhxgeaflzmzpmatnir.supabase.co/storage/v1/object/public/uploads/${props.userId()}.jpg`}
+          sizes="100vw"
+          alt=""
+          width={0}
+          height={0}
+          onError={() => setErrored(true)}
+        />
+      </Show>
     </div>
   )
 }

--- a/src/sections/common/components/icons/UserInitialFallback.tsx
+++ b/src/sections/common/components/icons/UserInitialFallback.tsx
@@ -1,0 +1,12 @@
+export function UserInitialFallback(props: { name: string; class?: string }) {
+  const initial = () => props.name.trim().charAt(0).toUpperCase()
+  return (
+    <div
+      class={`flex items-center justify-center bg-slate-700 text-white rounded-full font-bold ${props.class ?? ''}`.trim()}
+      aria-label={`User initial: ${initial()}`}
+      style={{ width: '100%', height: '100%' }}
+    >
+      <span class="">{initial()}</span>
+    </div>
+  )
+}

--- a/src/sections/common/components/icons/UserInitialFallback.tsx
+++ b/src/sections/common/components/icons/UserInitialFallback.tsx
@@ -2,11 +2,10 @@ export function UserInitialFallback(props: { name: string; class?: string }) {
   const initial = () => props.name.trim().charAt(0).toUpperCase()
   return (
     <div
-      class={`flex items-center justify-center bg-slate-700 text-white rounded-full font-bold ${props.class ?? ''}`.trim()}
+      class={`flex items-center justify-center bg-slate-700 text-white rounded-full font-bold w-full h-full text-3xl ${props.class ?? ''}`.trim()}
       aria-label={`User initial: ${initial()}`}
-      style={{ width: '100%', height: '100%' }}
     >
-      <span class="">{initial()}</span>
+      <span>{initial()}</span>
     </div>
   )
 }

--- a/src/sections/profile/components/UserInfo.tsx
+++ b/src/sections/profile/components/UserInfo.tsx
@@ -78,7 +78,11 @@ export function UserInfo() {
           <Show when={currentUser()}>
             {(user) => (
               <>
-                <UserIcon userId={user().id} class={'w-32 h-32 mx-auto'} />
+                <UserIcon
+                  userId={() => user().id}
+                  userName={() => user().name}
+                  class={'w-32 h-32 mx-auto'}
+                />
                 {user().name}
               </>
             )}


### PR DESCRIPTION
This PR implements a fallback for user profile icons that displays the user's initial when the profile image fails to load.

**What was changed:**
- Added a `UserInitialFallback` component to render a styled circle with the user's initial.
- Updated the `UserIcon` component to:
  - Accept the user's name as a prop.
  - Render the profile image as usual.
  - Detect image load failure and render the fallback with the user's initial.
- Refactored all usages of `UserIcon` to provide the user's name.
- Ensured the fallback icon matches the app's style and works in all user profile icon locations.

**Motivation:**
Improves user experience by ensuring a visual identifier is always present, even if the profile image fails to load.

**Implementation details:**
- The fallback is styled to match the app's design (size, color, font, etc.).
- All code, comments, and commits are in English.
- All code quality and test checks pass.

**Closes:**  
closes #750