### PR TITLE
fix: add version validation workflow for PRs to stable

### DIFF
--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: '16'
 
       - name: Validate package.json version
+        shell: bash
         run: |
           branch_version=$(echo ${{ github.head_ref }} | sed 's/^rc\///')
           package_version=$(jq -r .version package.json)
@@ -28,6 +29,7 @@ jobs:
           fi
 
       - name: Validate README.md version
+        shell: bash
         run: |
           branch_version=$(echo ${{ github.head_ref }} | sed 's/^rc\///')
           if ! grep -q "$branch_version" README.md; then
@@ -36,6 +38,7 @@ jobs:
           fi
 
       - name: Validate Git tag
+        shell: bash
         run: |
           branch_version=$(echo ${{ github.head_ref }} | sed 's/^rc\///')
           if ! git tag | grep -q "$branch_version"; then

--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -1,0 +1,44 @@
+name: Validate Version Consistency
+
+on:
+  pull_request:
+    branches:
+      - stable
+
+jobs:
+  validate-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Validate package.json version
+        run: |
+          branch_version=$(echo ${{ github.head_ref }} | sed 's/^rc\///')
+          package_version=$(jq -r .version package.json)
+          if [ "$branch_version" != "$package_version" ]; then
+            echo "Error: package.json version ($package_version) does not match branch version ($branch_version)."
+            exit 1
+          fi
+
+      - name: Validate README.md version
+        run: |
+          branch_version=$(echo ${{ github.head_ref }} | sed 's/^rc\///')
+          if ! grep -q "$branch_version" README.md; then
+            echo "Error: README.md does not contain the version $branch_version."
+            exit 1
+          fi
+
+      - name: Validate Git tag
+        run: |
+          branch_version=$(echo ${{ github.head_ref }} | sed 's/^rc\///')
+          if ! git tag | grep -q "$branch_version"; then
+            echo "Error: Git tag $branch_version does not exist."
+            exit 1
+          fi


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to validate version consistency when merging a pull request to the `stable` branch. The workflow ensures that:

1. The `package.json` version matches the version derived from the `rc/XXX` branch name.
2. The `README.md` contains the correct version.
3. A Git tag with the version `XXX` exists.

#### Changes
- Added a new workflow file `.github/workflows/version-validation.yml`.
- Configured the workflow to:
  - Validate `package.json` version.
  - Check for the correct version in `README.md`.
  - Verify the existence of the corresponding Git tag.
- Updated all steps to explicitly use the `bash` shell for full support of conditional logic.

#### Motivation
This change addresses issue #758 by ensuring that version mismatches are caught during the pull request process, preventing confusion and improving release traceability.

#### Implementation Details
- The workflow runs on pull requests targeting the `stable` branch.
- It uses `bash` for all steps to ensure compatibility with conditional logic.
- The workflow will fail and block the PR if any of the checks fail.

#### References
- Closes #758
