### PR TITLE
refactor(ui): unify copy button components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,7 @@ type(scope): description
 - Prefer small, atomic commits
 - Always suggest commit message after changes
 - All commit messages in English
+- **NEVER include "Generated with Claude Code" or "Co-Authored-By: Claude" in commit messages**
 ```
 
 ### JSDoc Requirements

--- a/src/sections/common/components/ClipboardActionButtons.tsx
+++ b/src/sections/common/components/ClipboardActionButtons.tsx
@@ -1,8 +1,9 @@
 import { JSXElement } from 'solid-js'
 
-import { CopyIcon } from '~/sections/common/components/icons/CopyIcon'
+import { CopyButton } from '~/sections/common/components/CopyButton'
 import { PasteIcon } from '~/sections/common/components/icons/PasteIcon'
 import { TrashIcon } from '~/sections/common/components/icons/TrashIcon'
+import { COPY_BUTTON_STYLES } from '~/sections/common/styles/buttonStyles'
 
 export type ClipboardActionButtonsProps = {
   canCopy: boolean
@@ -19,32 +20,20 @@ export function ClipboardActionButtons(
   return (
     <div class={'ml-auto flex gap-2'}>
       {props.canCopy && (
-        <div
-          class={
-            'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'
-          }
-          onClick={props.onCopy}
-        >
-          <CopyIcon />
-        </div>
+        <CopyButton
+          value={() => null}
+          onCopy={() => props.onCopy()}
+          class={COPY_BUTTON_STYLES}
+          stopPropagation={false}
+        />
       )}
       {props.canPaste && (
-        <div
-          class={
-            'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'
-          }
-          onClick={props.onPaste}
-        >
+        <div class={COPY_BUTTON_STYLES} onClick={props.onPaste}>
           <PasteIcon />
         </div>
       )}
       {props.canClear && (
-        <div
-          class={
-            'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'
-          }
-          onClick={props.onClear}
-        >
+        <div class={COPY_BUTTON_STYLES} onClick={props.onClear}>
           <TrashIcon />
         </div>
       )}

--- a/src/sections/common/components/CopyButton.tsx
+++ b/src/sections/common/components/CopyButton.tsx
@@ -1,21 +1,26 @@
 import { Accessor, JSXElement } from 'solid-js'
 
 import { CopyIcon } from '~/sections/common/components/icons/CopyIcon'
+import { COPY_BUTTON_STYLES } from '~/sections/common/styles/buttonStyles'
 
 export type CopyButtonProps<T> = {
   onCopy: (value: T) => void
   value: Accessor<T>
+  class?: string
+  stopPropagation?: boolean
 }
 
 export function CopyButton<T>(props: CopyButtonProps<T>): JSXElement {
+  const shouldStopPropagation = props.stopPropagation ?? true
+
   return (
     <div
-      class={
-        'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'
-      }
+      class={props.class ?? COPY_BUTTON_STYLES}
       onClick={(e) => {
-        e.stopPropagation()
-        e.preventDefault()
+        if (shouldStopPropagation) {
+          e.stopPropagation()
+          e.preventDefault()
+        }
         props.onCopy(props.value())
       }}
     >

--- a/src/sections/common/styles/buttonStyles.ts
+++ b/src/sections/common/styles/buttonStyles.ts
@@ -1,0 +1,2 @@
+export const COPY_BUTTON_STYLES =
+  'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'


### PR DESCRIPTION
## Summary

Unified copy button components to eliminate code duplication and improve maintainability. The main duplication was between `CopyButton.tsx` and `ClipboardActionButtons.tsx` which shared identical styling patterns but different implementations.

## Implementation Details

- **Extracted shared styles**: Created `COPY_BUTTON_STYLES` constant in `buttonStyles.ts` to centralize the common CSS classes
- **Enhanced CopyButton component**: Added optional `class` and `stopPropagation` props for greater flexibility
- **Refactored ClipboardActionButtons**: Replaced duplicated copy button implementation with the unified `CopyButton` component
- **Maintained backward compatibility**: All existing functionality and event handling behavior preserved
- **Applied consistent styling**: Used shared constants for paste and clear buttons to ensure visual consistency

## Key Changes

### Files Modified
- `src/sections/common/components/CopyButton.tsx` - Enhanced with optional props
- `src/sections/common/components/ClipboardActionButtons.tsx` - Refactored to use CopyButton
- `src/sections/common/styles/buttonStyles.ts` - New shared constants file
- `CLAUDE.md` - Added commit message guidelines

### Styling Unification
Before: Duplicated CSS classes across components
```tsx
'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'
```

After: Centralized constant with consistent usage
```tsx
export const COPY_BUTTON_STYLES = 'btn-ghost btn cursor-pointer uppercase ml-auto mt-1 px-2 text-white hover:scale-105'
```

## Testing

- ✅ All tests pass (`pnpm test`)
- ✅ TypeScript compilation succeeds (`pnpm type-check`)  
- ✅ ESLint checks pass (`pnpm lint`)
- ✅ Comprehensive quality checks pass (`pnpm check`)

## Architecture Compliance

- Maintains clean separation of concerns
- Follows existing import patterns with absolute paths
- Preserves component interface contracts
- No breaking changes to existing functionality

Closes #852