### PR TITLE
refactor(application): remove unused dayId parameters from meal operations

### DIFF
--- a/src/modules/diet/item-group/application/itemGroup.ts
+++ b/src/modules/diet/item-group/application/itemGroup.ts
@@ -28,7 +28,6 @@ import { handleApiError } from '~/shared/error/errorHandler'
  * @deprecated Use insertUnifiedItem instead
  */
 export async function insertItemGroup(
-  _dayId: DayDiet['id'], // TODO:   Remove dayId from functions that don't need it.
   mealId: Meal['id'],
   newItemGroup: ItemGroup,
 ) {
@@ -65,7 +64,6 @@ export async function insertItemGroup(
 }
 
 export async function updateItemGroup(
-  _dayId: DayDiet['id'], // TODO:   Remove dayId from functions that don't need it.
   mealId: Meal['id'],
   itemGroupId: ItemGroup['id'],
   newItemGroup: ItemGroup,
@@ -103,7 +101,6 @@ export async function updateItemGroup(
 }
 
 export async function deleteItemGroup(
-  _dayId: DayDiet['id'], // TODO:   Remove dayId from functions that don't need it
   mealId: Meal['id'],
   itemGroupId: ItemGroup['id'],
 ) {
@@ -143,7 +140,6 @@ export async function deleteItemGroup(
  * Inserts a UnifiedItem directly into a meal (new unified approach)
  */
 export async function insertUnifiedItem(
-  _dayId: DayDiet['id'],
   mealId: Meal['id'],
   newUnifiedItem: UnifiedItem,
 ) {
@@ -183,7 +179,6 @@ export async function insertUnifiedItem(
  * Updates a UnifiedItem in a meal (new unified approach)
  */
 export async function updateUnifiedItem(
-  _dayId: DayDiet['id'],
   mealId: Meal['id'],
   itemId: UnifiedItem['id'],
   newUnifiedItem: UnifiedItem,
@@ -224,7 +219,6 @@ export async function updateUnifiedItem(
  * Deletes a UnifiedItem from a meal (new unified approach)
  */
 export async function deleteUnifiedItem(
-  _dayId: DayDiet['id'],
   mealId: Meal['id'],
   itemId: UnifiedItem['id'],
 ) {
@@ -264,10 +258,9 @@ export async function deleteUnifiedItem(
  * Converts ItemGroup to UnifiedItem and inserts it (compatibility helper)
  */
 export async function insertItemGroupAsUnified(
-  dayId: DayDiet['id'],
   mealId: Meal['id'],
   itemGroup: ItemGroup,
 ) {
   const unifiedItem = itemGroupToUnifiedItem(itemGroup)
-  return insertUnifiedItem(dayId, mealId, unifiedItem)
+  return insertUnifiedItem(mealId, unifiedItem)
 }

--- a/src/modules/diet/meal/application/meal.ts
+++ b/src/modules/diet/meal/application/meal.ts
@@ -16,13 +16,11 @@ export const dayMeals = () => currentDayDiet()?.meals ?? []
 
 /**
  * Updates a meal in the current day diet.
- * @param _dayId - The day diet ID (unused).
  * @param mealId - The meal ID.
  * @param newMeal - The new meal data.
  * @returns True if updated, false otherwise.
  */
 export async function updateMeal(
-  _dayId: DayDiet['id'],
   mealId: Meal['id'],
   newMeal: Meal,
 ): Promise<boolean> {

--- a/src/sections/day-diet/components/DayMeals.tsx
+++ b/src/sections/day-diet/components/DayMeals.tsx
@@ -83,7 +83,7 @@ export default function DayMeals(props: {
       setShowConfirmEdit(true)
       return
     }
-    await updateMeal(day.id, meal.id, meal)
+    await updateMeal(meal.id, meal)
   }
 
   const handleNewItemButton = (meal: Meal) => {
@@ -101,7 +101,7 @@ export default function DayMeals(props: {
     if (newItemSelection_ === null) {
       throw new Error('No meal selected!')
     }
-    void insertUnifiedItem(dayDiet.id, newItemSelection_.meal.id, newItem)
+    void insertUnifiedItem(newItemSelection_.meal.id, newItem)
   }
 
   const handleFinishSearch = () => {
@@ -274,7 +274,6 @@ function ExternalUnifiedItemEditModal(props: {
             }}
             onApply={(item) => {
               void updateUnifiedItem(
-                props.day().id,
                 editSelection().meal.id,
                 item.id, // TODO: Get id from selection instead of item parameter (avoid bugs if id is changed).
                 item,

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -261,7 +261,7 @@ export function MealEditViewContent(props: {
                 text: 'Excluir item',
                 primary: true,
                 onClick: () => {
-                  void deleteUnifiedItem(dayDiet().id, meal().id, item.id)
+                  void deleteUnifiedItem(meal().id, item.id)
                 },
               },
             ],


### PR DESCRIPTION
## Summary
Removes unused `_dayId` parameter from application layer functions that don't actually use the dayId since they retrieve the current day diet from global state.

## Implementation Details
- **Functions Updated:** 8 functions across 2 modules had their unused `_dayId: DayDiet['id']` parameter removed
- **Meal Module:** `updateMeal()` function signature simplified
- **Item Group Module:** 7 functions (`insertItemGroup`, `updateItemGroup`, `deleteItemGroup`, `insertUnifiedItem`, `updateUnifiedItem`, `deleteUnifiedItem`, `insertItemGroupAsUnified`) simplified
- **Calling Sites:** Updated 4 calling sites in UI components to remove the dayId argument

## Benefits
- **Cleaner API:** Removes misleading unused parameters that suggested dayId was needed
- **Consistency:** All functions now consistently rely on `currentDayDiet()` global state
- **Maintainability:** Reduces confusion about parameter usage and potential for passing wrong dayId values
- **Type Safety:** Eliminates possibility of runtime errors from incorrect dayId parameter usage

## Technical Changes
All modified functions internally use `currentDayDiet()` to get the current day diet rather than relying on a passed parameter. This change:
- Maintains identical runtime behavior
- Improves function signature clarity
- Follows the established pattern in the codebase

## Testing
- ✅ All existing tests pass (236/239, 3 skipped)
- ✅ TypeScript compilation successful
- ✅ ESLint checks pass
- ✅ No behavioral changes - functions work identically

## Files Changed
- `src/modules/diet/meal/application/meal.ts`
- `src/modules/diet/item-group/application/itemGroup.ts`
- `src/sections/day-diet/components/DayMeals.tsx`  
- `src/sections/meal/components/MealEditView.tsx`

Closes #723