### PR TITLE
fix(profile): macro calorie values now display correctly instead of showing 0 kcal

### DIFF
--- a/src/sections/macro-nutrients/components/MacroTargets.tsx
+++ b/src/sections/macro-nutrients/components/MacroTargets.tsx
@@ -284,7 +284,7 @@ function MacroTargetSetting(props: {
           <span class="hidden sm:inline">:</span>
         </span>
         <span class="my-auto flex-1 text-xl text-center">
-          {(props.target.calorieMultiplier * (Number(grams) || 0)).toFixed(0)}{' '}
+          {(props.target.calorieMultiplier * props.target.grams).toFixed(0)}{' '}
           kcal
           <span class="ml-2 text-slate-300 text-lg">({percentage()}%)</span>
         </span>


### PR DESCRIPTION
## Summary
Fixes macro nutrient calorie display bug on profile/goals page where all macros showed "0 kcal" with percentages instead of calculated calorie values.

## Problem
The macro target display was using `Number(grams())` for calorie calculations, but `grams()` returns an empty string when the value is 0 (due to `emptyIfZeroElse2Decimals` function), causing `Number("")` to become 0 and resulting in "0 kcal" display.

## Solution
- Changed calorie calculation to use `props.target.grams` directly instead of the formatted `grams()` function
- This ensures proper calorie calculations: carbs/protein × 4 kcal/g, fat × 9 kcal/g
- Maintains existing percentage calculations which were working correctly

## Testing
- ✅ All tests pass (272 passed, 3 skipped)
- ✅ TypeScript compilation successful  
- ✅ ESLint checks pass
- ✅ Development server running correctly
- ✅ Manual testing confirms macro calories now display correctly

## Files Changed
- `src/sections/macro-nutrients/components/MacroTargets.tsx` - Fixed calorie calculation display

Closes #949