### PR TITLE
chore(day-diet): finalize days table rename from days_test to days

### DIFF
--- a/src/modules/diet/day-diet/application/dayDiet.ts
+++ b/src/modules/diet/day-diet/application/dayDiet.ts
@@ -123,6 +123,7 @@ createEffect(() => {
 /**
  * When realtime day diets change, update day diets for current user
  */
+// TODO: Move all registerSubapabaseRealtimeCallback to infra layer
 registerSubapabaseRealtimeCallback(SUPABASE_TABLE_DAYS, () => {
   bootstrap()
 })

--- a/src/modules/diet/day-diet/infrastructure/supabaseDayRepository.ts
+++ b/src/modules/diet/day-diet/infrastructure/supabaseDayRepository.ts
@@ -22,8 +22,7 @@ import {
 } from '~/shared/error/errorHandler'
 import supabase from '~/shared/utils/supabase'
 
-// TODO:   Delete old days table and rename days_test to days
-export const SUPABASE_TABLE_DAYS = 'days_test'
+export const SUPABASE_TABLE_DAYS = 'days'
 
 const errorHandler = createErrorHandler('infrastructure', 'DayDiet')
 


### PR DESCRIPTION
## Summary
Completes the database table migration by updating the table name reference from `days_test` to `days` in the day diet infrastructure.

## Implementation Details
- Updated `SUPABASE_TABLE_DAYS` constant from `'days_test'` to `'days'`
- Removed TODO comment about deleting old days table
- Added TODO comment about moving realtime callbacks to infrastructure layer

## Testing
- Verified table name change doesn't break existing functionality
- Confirmed realtime subscriptions continue to work with new table name

Closes #461
EOF < /dev/null