### PR TITLE
fix(clipboard): improve paste UX (use paste event + focused modal)

### DIFF
--- a/src/sections/common/hooks/useClipboard.tsx
+++ b/src/sections/common/hooks/useClipboard.tsx
@@ -1,4 +1,3 @@
-import { createEffect, createSignal } from 'solid-js'
 import { type z } from 'zod/v4'
 
 import {
@@ -19,20 +18,16 @@ export function useClipboard(props?: {
   periodicRead?: boolean
 }) {
   const filter = () => props?.filter
-  const periodicRead = () => props?.periodicRead ?? true
-  const [clipboard, setClipboard] = createSignal('')
 
   const handleWrite = (text: string, onError?: (error: unknown) => void) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (window.navigator.clipboard === undefined) {
       showError(`Clipboard API not supported`)
-      setClipboard('')
       return
     }
     window.navigator.clipboard
       .writeText(text)
       .then(() => {
-        setClipboard(text)
         if (text.length > 0) {
           showSuccess(`Copiado com sucesso`)
         }
@@ -46,41 +41,23 @@ export function useClipboard(props?: {
       })
   }
 
-  const handleRead = () => {
-    const afterRead = (newClipboard: string) => {
-      const filter_ = filter()
-      if (filter_ !== undefined && !filter_(newClipboard)) {
-        setClipboard('')
-        return
-      }
-
-      setClipboard(newClipboard)
-    }
+  const handleRead = async () => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (window.navigator.clipboard === undefined) {
-      // Clipboard API not supported, set empty clipboard
-      setClipboard('')
-      return
+      return ''
     }
-    window.navigator.clipboard
+    const clipboardText = await window.navigator.clipboard
       .readText()
-      .then(afterRead)
-      .catch(() => {
-        // Do nothing. This is expected when the DOM is not focused
-      })
-  }
-  // Update clipboard periodically
-  createEffect(() => {
-    if (!periodicRead()) return
+      .catch(() => '')
 
-    const interval = setInterval(handleRead, 1000)
-    return () => {
-      clearInterval(interval)
+    if (filter()?.(clipboardText) ?? true) {
+      return clipboardText
     }
-  })
+
+    return ''
+  }
 
   return {
-    clipboard,
     write: handleWrite,
     read: handleRead,
     clear: () => {

--- a/src/sections/common/hooks/useCopyPasteActions.ts
+++ b/src/sections/common/hooks/useCopyPasteActions.ts
@@ -7,13 +7,6 @@ import {
 import { openConfirmModal } from '~/shared/modal/helpers/modalHelpers'
 import { deserializeClipboard } from '~/shared/utils/clipboardUtils'
 
-/**
- * Shared clipboard copy/paste logic for meal/recipe editors.
- * @param options
- *   - acceptedClipboardSchema: zod schema for validation
- *   - getDataToCopy: function to get the data to copy
- *   - onPaste: function to handle parsed clipboard data
- */
 export function useCopyPasteActions<T>({
   acceptedClipboardSchema,
   getDataToCopy,
@@ -46,7 +39,56 @@ export function useCopyPasteActions<T>({
     clearClipboard()
   }
 
-  const handlePaste = () => {
+  type PasteEventLike =
+    | ClipboardEvent
+    | {
+        clipboardData?: DataTransfer | null
+        preventDefault?: () => void
+      }
+
+  const handlePaste = (pasteEvent?: PasteEventLike) => {
+    const processClipboardText = async (
+      clipboardText: string,
+      clearWhenFromApi = true,
+    ) => {
+      const data = deserializeClipboard(clipboardText, acceptedClipboardSchema)
+      if (data === null) {
+        throw new Error('Invalid clipboard data: ' + clipboardText)
+      }
+      onPaste(data)
+      if (clearWhenFromApi) clearClipboard()
+    }
+
+    let eventClipboardText: string | null = null
+    if (
+      pasteEvent &&
+      'clipboardData' in pasteEvent &&
+      pasteEvent.clipboardData
+    ) {
+      try {
+        eventClipboardText = pasteEvent.clipboardData.getData('text') || null
+      } catch {
+        eventClipboardText = null
+      }
+    }
+
+    if (eventClipboardText !== null) {
+      try {
+        pasteEvent?.preventDefault?.()
+      } catch {
+        // ignore if cannot prevent
+      }
+
+      openConfirmModal('Tem certeza que deseja colar os itens?', {
+        title: 'Colar itens',
+        confirmText: 'Colar',
+        cancelText: 'Cancelar',
+        onConfirm: () => processClipboardText(eventClipboardText, false),
+      })
+      return
+    }
+
+    // No event-provided clipboard data: use the previous flow (confirmation -> clipboard API)
     openConfirmModal('Tem certeza que deseja colar os itens?', {
       title: 'Colar itens',
       confirmText: 'Colar',

--- a/src/sections/common/hooks/useCopyPasteActions.ts
+++ b/src/sections/common/hooks/useCopyPasteActions.ts
@@ -25,19 +25,22 @@ export function useCopyPasteActions<T>({
 }) {
   const isClipboardValid = createClipboardSchemaFilter(acceptedClipboardSchema)
   const {
-    clipboard: clipboardText,
+    read: readFromClipboard,
     write: writeToClipboard,
     clear: clearClipboard,
-  } = useClipboard({ filter: isClipboardValid })
+  } = useClipboard({
+    filter: isClipboardValid,
+  })
 
   const handleCopy = () => {
     writeToClipboard(JSON.stringify(getDataToCopy()))
   }
 
-  const handlePasteAfterConfirm = () => {
-    const data = deserializeClipboard(clipboardText(), acceptedClipboardSchema)
+  const handlePasteAfterConfirm = async () => {
+    const clipboardText = await readFromClipboard()
+    const data = deserializeClipboard(clipboardText, acceptedClipboardSchema)
     if (data === null) {
-      throw new Error('Invalid clipboard data: ' + clipboardText())
+      throw new Error('Invalid clipboard data: ' + clipboardText)
     }
     onPaste(data)
     clearClipboard()
@@ -52,10 +55,10 @@ export function useCopyPasteActions<T>({
     })
   }
 
-  const hasValidPastableOnClipboard = () => isClipboardValid(clipboardText())
+  const hasValidPastableOnClipboard = async () =>
+    isClipboardValid(await readFromClipboard())
 
   return {
-    clipboardText,
     writeToClipboard,
     clearClipboard,
     handleCopy,

--- a/src/sections/common/hooks/useCopyPasteActions.tsx
+++ b/src/sections/common/hooks/useCopyPasteActions.tsx
@@ -4,7 +4,11 @@ import {
   createClipboardSchemaFilter,
   useClipboard,
 } from '~/sections/common/hooks/useClipboard'
-import { openConfirmModal } from '~/shared/modal/helpers/modalHelpers'
+import {
+  closeModal,
+  openConfirmModal,
+  openContentModal,
+} from '~/shared/modal/helpers/modalHelpers'
 import { deserializeClipboard } from '~/shared/utils/clipboardUtils'
 
 export function useCopyPasteActions<T>({
@@ -88,13 +92,62 @@ export function useCopyPasteActions<T>({
       return
     }
 
-    // No event-provided clipboard data: use the previous flow (confirmation -> clipboard API)
-    openConfirmModal('Tem certeza que deseja colar os itens?', {
-      title: 'Colar itens',
-      confirmText: 'Colar',
-      cancelText: 'Cancelar',
-      onConfirm: handlePasteAfterConfirm,
-    })
+    const modalId = openContentModal((mid) => (
+      <div class="p-4">
+        <p class="mb-2">
+          Cole os itens agora (pressione <strong>Ctrl/Cmd+V</strong>)
+        </p>
+        <div
+          id={`paste-target-${mid}`}
+          tabindex={0}
+          class="w-full h-24 rounded bg-gray-800 border border-gray-700 p-2 overflow-auto"
+          onPaste={(e: ClipboardEvent) => {
+            try {
+              const text = e.clipboardData?.getData('text') ?? ''
+              void closeModal(mid)
+              void processClipboardText(text, false)
+            } catch {
+              // ignore and keep modal open
+            }
+          }}
+        >
+          <div class="text-sm text-gray-400">
+            Foco aqui — pressione Ctrl/Cmd+V
+          </div>
+        </div>
+
+        <div class="mt-4 flex gap-2 justify-end">
+          <button
+            class="btn btn-ghost"
+            onClick={() => {
+              void closeModal(mid)
+              openConfirmModal('Tem certeza que deseja colar os itens?', {
+                title: 'Colar itens',
+                confirmText: 'Colar',
+                cancelText: 'Cancelar',
+                onConfirm: handlePasteAfterConfirm,
+              })
+            }}
+          >
+            Colar do clipboard (fallback)
+          </button>
+          <button
+            class="btn btn-primary"
+            onClick={() => {
+              void closeModal(mid)
+            }}
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    ))
+
+    // Focus the paste target element so the user can immediately press Ctrl/Cmd+V
+    setTimeout(() => {
+      const el = document.getElementById(`paste-target-${modalId}`)
+      el?.focus()
+    }, 0)
   }
 
   const hasValidPastableOnClipboard = async () =>

--- a/src/sections/common/hooks/useCopyPasteActions.tsx
+++ b/src/sections/common/hooks/useCopyPasteActions.tsx
@@ -150,14 +150,10 @@ export function useCopyPasteActions<T>({
     }, 0)
   }
 
-  const hasValidPastableOnClipboard = async () =>
-    isClipboardValid(await readFromClipboard())
-
   return {
     writeToClipboard,
     clearClipboard,
     handleCopy,
     handlePaste,
-    hasValidPastableOnClipboard,
   }
 }

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -173,7 +173,7 @@ export function MealEditViewHeader(props: {
   return (
     <Show when={meal()}>
       {(mealSignal) => (
-        <div class="flex">
+        <div class="flex" tabindex={0} onPaste={(e) => handlePaste(e)}>
           <div class="my-2">
             <h5 class="text-3xl">{mealSignal().name}</h5>
             <p class="italic text-gray-400">{mealCalories().toFixed(0)}kcal</p>

--- a/src/sections/meal/components/MealEditView.tsx
+++ b/src/sections/meal/components/MealEditView.tsx
@@ -90,73 +90,72 @@ export function MealEditViewHeader(props: {
     .or(unifiedItemSchema)
     .or(z.array(unifiedItemSchema))
 
-  const { handleCopy, handlePaste, hasValidPastableOnClipboard } =
-    useCopyPasteActions({
-      acceptedClipboardSchema,
-      getDataToCopy: () => meal(),
-      onPaste: (data) => {
-        // Check if data is already UnifiedItem(s) and handle directly
-        if (Array.isArray(data)) {
-          const firstItem = data[0]
-          if (firstItem && '__type' in firstItem) {
-            // Handle array of UnifiedItems - type is already validated by schema
-            const unifiedItemsToAdd = data.map((item) => ({
-              ...item,
-              id: regenerateId(item).id,
-            }))
-
-            // Update the meal with all items at once
-            const updatedMeal = addItemsToMeal(meal(), unifiedItemsToAdd)
-            props.onUpdateMeal(updatedMeal)
-            return
-          }
-        }
-
-        if (
-          typeof data === 'object' &&
-          '__type' in data &&
-          data.__type === 'Meal'
-        ) {
-          // Handle pasted Meal - extract its items and add them to current meal
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          const mealData = data as Meal
-          logging.debug('Pasting meal with items:', { mealData })
-          const unifiedItemsToAdd = mealData.items.map((item) => ({
+  const { handleCopy, handlePaste } = useCopyPasteActions({
+    acceptedClipboardSchema,
+    getDataToCopy: () => meal(),
+    onPaste: (data) => {
+      // Check if data is already UnifiedItem(s) and handle directly
+      if (Array.isArray(data)) {
+        const firstItem = data[0]
+        if (firstItem && '__type' in firstItem) {
+          // Handle array of UnifiedItems - type is already validated by schema
+          const unifiedItemsToAdd = data.map((item) => ({
             ...item,
             id: regenerateId(item).id,
           }))
-          logging.debug('Items to add:', { unifiedItemsToAdd })
 
           // Update the meal with all items at once
           const updatedMeal = addItemsToMeal(meal(), unifiedItemsToAdd)
           props.onUpdateMeal(updatedMeal)
           return
         }
+      }
 
-        if (
-          typeof data === 'object' &&
-          '__type' in data &&
-          data.__type === 'UnifiedItem'
-        ) {
-          // Handle single UnifiedItem - type is already validated by schema
-          const regeneratedItem = {
-            ...data,
-            id: regenerateId(data).id,
-          }
+      if (
+        typeof data === 'object' &&
+        '__type' in data &&
+        data.__type === 'Meal'
+      ) {
+        // Handle pasted Meal - extract its items and add them to current meal
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const mealData = data as Meal
+        logging.debug('Pasting meal with items:', { mealData })
+        const unifiedItemsToAdd = mealData.items.map((item) => ({
+          ...item,
+          id: regenerateId(item).id,
+        }))
+        logging.debug('Items to add:', { unifiedItemsToAdd })
 
-          // Update the meal with the single item
-          const updatedMeal = addItemsToMeal(meal(), [regeneratedItem])
-          props.onUpdateMeal(updatedMeal)
-          return
+        // Update the meal with all items at once
+        const updatedMeal = addItemsToMeal(meal(), unifiedItemsToAdd)
+        props.onUpdateMeal(updatedMeal)
+        return
+      }
+
+      if (
+        typeof data === 'object' &&
+        '__type' in data &&
+        data.__type === 'UnifiedItem'
+      ) {
+        // Handle single UnifiedItem - type is already validated by schema
+        const regeneratedItem = {
+          ...data,
+          id: regenerateId(data).id,
         }
 
-        // Handle other types supported by schema (recipes, etc.)
-        // Since schema validation passed, this should be a recipe
-        // For now, we'll skip unsupported formats in paste
-        // TODO: Add proper recipe-to-items conversion if needed
-        logging.warn('Unsupported paste format:', { data })
-      },
-    })
+        // Update the meal with the single item
+        const updatedMeal = addItemsToMeal(meal(), [regeneratedItem])
+        props.onUpdateMeal(updatedMeal)
+        return
+      }
+
+      // Handle other types supported by schema (recipes, etc.)
+      // Since schema validation passed, this should be a recipe
+      // For now, we'll skip unsupported formats in paste
+      // TODO: Add proper recipe-to-items conversion if needed
+      logging.warn('Unsupported paste format:', { data })
+    },
+  })
 
   const mealCalories = () => calcMealCalories(meal())
 
@@ -181,10 +180,8 @@ export function MealEditViewHeader(props: {
           </div>
           {props.mode !== 'summary' && (
             <ClipboardActionButtons
-              canCopy={
-                !hasValidPastableOnClipboard() && mealSignal().items.length > 0
-              }
-              canPaste={hasValidPastableOnClipboard()}
+              canCopy={mealSignal().items.length > 0}
+              canPaste={true}
               canClear={mealSignal().items.length > 0}
               onCopy={handleCopy}
               onPaste={handlePaste}

--- a/src/sections/recipe/components/RecipeEditView.tsx
+++ b/src/sections/recipe/components/RecipeEditView.tsx
@@ -114,7 +114,7 @@ export function RecipeEditHeader(props: {
   }
 
   return (
-    <div class="flex">
+    <div class="flex" tabindex={0} onPaste={(e) => handlePaste(e)}>
       <div class="my-2">
         <h5 class="text-3xl text-blue-500">{recipe().name}</h5>
         <p class="italic text-gray-400">{recipeCalories.toFixed(0)}kcal</p>

--- a/src/sections/recipe/components/RecipeEditView.tsx
+++ b/src/sections/recipe/components/RecipeEditView.tsx
@@ -60,46 +60,45 @@ export function RecipeEditHeader(props: {
 
   const { recipe } = useRecipeEditContext()
 
-  const { handleCopy, handlePaste, hasValidPastableOnClipboard } =
-    useCopyPasteActions({
-      acceptedClipboardSchema,
-      getDataToCopy: () => recipe(),
-      onPaste: (data) => {
-        // Helper function to check if an object is a UnifiedItem
-        const isUnifiedItem = (obj: unknown): obj is UnifiedItem => {
-          return (
-            typeof obj === 'object' &&
-            obj !== null &&
-            '__type' in obj &&
-            obj.__type === 'UnifiedItem'
-          )
-        }
+  const { handleCopy, handlePaste } = useCopyPasteActions({
+    acceptedClipboardSchema,
+    getDataToCopy: () => recipe(),
+    onPaste: (data) => {
+      // Helper function to check if an object is a UnifiedItem
+      const isUnifiedItem = (obj: unknown): obj is UnifiedItem => {
+        return (
+          typeof obj === 'object' &&
+          obj !== null &&
+          '__type' in obj &&
+          obj.__type === 'UnifiedItem'
+        )
+      }
 
-        // Check if data is array of UnifiedItems
-        if (Array.isArray(data) && data.every(isUnifiedItem)) {
-          const itemsToAdd = data
-            .filter((item) => item.reference.type === 'food') // Only food items in recipes
-            .map((item) => regenerateId(item))
-          const newRecipe = addItemsToRecipe(recipe(), itemsToAdd)
+      // Check if data is array of UnifiedItems
+      if (Array.isArray(data) && data.every(isUnifiedItem)) {
+        const itemsToAdd = data
+          .filter((item) => item.reference.type === 'food') // Only food items in recipes
+          .map((item) => regenerateId(item))
+        const newRecipe = addItemsToRecipe(recipe(), itemsToAdd)
+        props.onUpdateRecipe(newRecipe)
+        return
+      }
+
+      // Check if data is single UnifiedItem
+      if (isUnifiedItem(data)) {
+        if (data.reference.type === 'food') {
+          const item = data
+          const regeneratedItem = regenerateId(item)
+          const newRecipe = addItemsToRecipe(recipe(), [regeneratedItem])
           props.onUpdateRecipe(newRecipe)
-          return
         }
+        return
+      }
 
-        // Check if data is single UnifiedItem
-        if (isUnifiedItem(data)) {
-          if (data.reference.type === 'food') {
-            const item = data
-            const regeneratedItem = regenerateId(item)
-            const newRecipe = addItemsToRecipe(recipe(), [regeneratedItem])
-            props.onUpdateRecipe(newRecipe)
-          }
-          return
-        }
-
-        // Handle other supported clipboard formats
-        logging.warn('Unsupported paste format:', data)
-      },
-    })
+      // Handle other supported clipboard formats
+      logging.warn('Unsupported paste format:', data)
+    },
+  })
 
   const recipeCalories = calcRecipeCalories(recipe())
 
@@ -121,8 +120,8 @@ export function RecipeEditHeader(props: {
         <p class="italic text-gray-400">{recipeCalories.toFixed(0)}kcal</p>
       </div>
       <ClipboardActionButtons
-        canCopy={!hasValidPastableOnClipboard() && recipe().items.length > 0}
-        canPaste={hasValidPastableOnClipboard()}
+        canCopy={recipe().items.length > 0}
+        canPaste={true}
         canClear={recipe().items.length > 0}
         onCopy={handleCopy}
         onPaste={handlePaste}

--- a/src/sections/recipe/components/UnifiedRecipeEditView.tsx
+++ b/src/sections/recipe/components/UnifiedRecipeEditView.tsx
@@ -103,7 +103,11 @@ export function RecipeEditView(props: RecipeEditViewProps) {
   }
 
   return (
-    <div class="flex flex-col gap-2 w-full">
+    <div
+      class="flex flex-col gap-2 w-full"
+      tabindex={0}
+      onPaste={(e) => handlePaste(e)}
+    >
       {props.header}
       <ClipboardActionButtons
         canCopy={recipe().items.length > 0}

--- a/src/sections/recipe/components/UnifiedRecipeEditView.tsx
+++ b/src/sections/recipe/components/UnifiedRecipeEditView.tsx
@@ -51,45 +51,44 @@ export function RecipeEditView(props: RecipeEditViewProps) {
     mealSchema,
   ])
 
-  const { handleCopy, handlePaste, hasValidPastableOnClipboard } =
-    useCopyPasteActions({
-      acceptedClipboardSchema,
-      getDataToCopy: () => [...recipe().items],
-      onPaste: (data) => {
-        // Helper function to check if an object is a UnifiedItem
-        const isUnifiedItem = (obj: unknown): obj is UnifiedItem => {
-          return (
-            typeof obj === 'object' &&
-            obj !== null &&
-            '__type' in obj &&
-            obj.__type === 'UnifiedItem'
-          )
-        }
+  const { handleCopy, handlePaste } = useCopyPasteActions({
+    acceptedClipboardSchema,
+    getDataToCopy: () => [...recipe().items],
+    onPaste: (data) => {
+      // Helper function to check if an object is a UnifiedItem
+      const isUnifiedItem = (obj: unknown): obj is UnifiedItem => {
+        return (
+          typeof obj === 'object' &&
+          obj !== null &&
+          '__type' in obj &&
+          obj.__type === 'UnifiedItem'
+        )
+      }
 
-        // Check if data is array of UnifiedItems
-        if (Array.isArray(data) && data.every(isUnifiedItem)) {
-          const itemsToAdd = data
-            .filter((item) => item.reference.type === 'food') // Only food items in recipes
-            .map((item) => regenerateId(item))
-          const newRecipe = addItemsToRecipe(recipe(), itemsToAdd)
+      // Check if data is array of UnifiedItems
+      if (Array.isArray(data) && data.every(isUnifiedItem)) {
+        const itemsToAdd = data
+          .filter((item) => item.reference.type === 'food') // Only food items in recipes
+          .map((item) => regenerateId(item))
+        const newRecipe = addItemsToRecipe(recipe(), itemsToAdd)
+        setRecipe(newRecipe)
+        return
+      }
+
+      // Check if data is single UnifiedItem
+      if (isUnifiedItem(data)) {
+        if (data.reference.type === 'food') {
+          const regeneratedItem = regenerateId(data)
+          const newRecipe = addItemsToRecipe(recipe(), [regeneratedItem])
           setRecipe(newRecipe)
-          return
         }
+        return
+      }
 
-        // Check if data is single UnifiedItem
-        if (isUnifiedItem(data)) {
-          if (data.reference.type === 'food') {
-            const regeneratedItem = regenerateId(data)
-            const newRecipe = addItemsToRecipe(recipe(), [regeneratedItem])
-            setRecipe(newRecipe)
-          }
-          return
-        }
-
-        // Handle other supported clipboard formats
-        logging.warn('Unsupported paste format:', data)
-      },
-    })
+      // Handle other supported clipboard formats
+      logging.warn('Unsupported paste format:', data)
+    },
+  })
 
   const recipeCalories = calcRecipeCalories(recipe())
 
@@ -108,7 +107,7 @@ export function RecipeEditView(props: RecipeEditViewProps) {
       {props.header}
       <ClipboardActionButtons
         canCopy={recipe().items.length > 0}
-        canPaste={hasValidPastableOnClipboard()}
+        canPaste={true}
         canClear={recipe().items.length > 0}
         onCopy={handleCopy}
         onPaste={handlePaste}

--- a/src/sections/unified-item/components/GroupChildrenEditor.tsx
+++ b/src/sections/unified-item/components/GroupChildrenEditor.tsx
@@ -51,59 +51,58 @@ export function GroupChildrenEditor(props: GroupChildrenEditorProps) {
   )
 
   // Clipboard actions for children
-  const { handleCopy, handlePaste, hasValidPastableOnClipboard } =
-    useCopyPasteActions({
-      acceptedClipboardSchema,
-      getDataToCopy: () => children(),
-      onPaste: (data) => {
-        const itemsToAdd = Array.isArray(data) ? data : [data]
+  const { handleCopy, handlePaste } = useCopyPasteActions({
+    acceptedClipboardSchema,
+    getDataToCopy: () => children(),
+    onPaste: (data) => {
+      const itemsToAdd = Array.isArray(data) ? data : [data]
 
-        let updatedItem = props.item()
+      let updatedItem = props.item()
 
-        // Check if we need to transform a food item into a group
-        if (isFoodItem(updatedItem) && itemsToAdd.length > 0) {
-          // Transform the food item into a group with the original food as the first child
-          const originalAsChild = createUnifiedItem({
-            id: generateId(), // New ID for the child
-            name: updatedItem.name,
-            quantity: updatedItem.quantity,
-            reference: updatedItem.reference, // Keep the food reference
-          })
+      // Check if we need to transform a food item into a group
+      if (isFoodItem(updatedItem) && itemsToAdd.length > 0) {
+        // Transform the food item into a group with the original food as the first child
+        const originalAsChild = createUnifiedItem({
+          id: generateId(), // New ID for the child
+          name: updatedItem.name,
+          quantity: updatedItem.quantity,
+          reference: updatedItem.reference, // Keep the food reference
+        })
 
-          // Create new group with the original food as first child
-          updatedItem = createUnifiedItem({
-            id: updatedItem.id, // Keep the same ID for the parent
-            name: updatedItem.name,
-            quantity: updatedItem.quantity,
-            reference: {
-              type: 'group',
-              children: [originalAsChild],
-            },
-          })
+        // Create new group with the original food as first child
+        updatedItem = createUnifiedItem({
+          id: updatedItem.id, // Keep the same ID for the parent
+          name: updatedItem.name,
+          quantity: updatedItem.quantity,
+          reference: {
+            type: 'group',
+            children: [originalAsChild],
+          },
+        })
+      }
+
+      for (const newChild of itemsToAdd) {
+        // Regenerate ID to avoid conflicts
+        const childWithNewId = {
+          ...newChild,
+          id: regenerateId(newChild).id,
         }
 
-        for (const newChild of itemsToAdd) {
-          // Regenerate ID to avoid conflicts
-          const childWithNewId = {
-            ...newChild,
-            id: regenerateId(newChild).id,
-          }
-
-          // Validate hierarchy to prevent circular references
-          const tempItem = addChildToItem(updatedItem, childWithNewId)
-          if (!validateItemHierarchy(tempItem)) {
-            logging.warn(
-              `Skipping item ${childWithNewId.name} - would create circular reference`,
-            )
-            continue
-          }
-
-          updatedItem = tempItem
+        // Validate hierarchy to prevent circular references
+        const tempItem = addChildToItem(updatedItem, childWithNewId)
+        if (!validateItemHierarchy(tempItem)) {
+          logging.warn(
+            `Skipping item ${childWithNewId.name} - would create circular reference`,
+          )
+          continue
         }
 
-        props.setItem(updatedItem)
-      },
-    })
+        updatedItem = tempItem
+      }
+
+      props.setItem(updatedItem)
+    },
+  })
 
   const updateChildQuantity = (childId: number, newQuantity: number) => {
     logging.debug('[GroupChildrenEditor] updateChildQuantity', {
@@ -193,7 +192,7 @@ export function GroupChildrenEditor(props: GroupChildrenEditorProps) {
         {/* Clipboard Actions */}
         <ClipboardActionButtons
           canCopy={children().length > 0}
-          canPaste={hasValidPastableOnClipboard()}
+          canPaste={true}
           canClear={false} // We don't need clear functionality here
           onCopy={handleCopy}
           onPaste={handlePaste}

--- a/src/sections/unified-item/components/GroupChildrenEditor.tsx
+++ b/src/sections/unified-item/components/GroupChildrenEditor.tsx
@@ -200,7 +200,7 @@ export function GroupChildrenEditor(props: GroupChildrenEditorProps) {
         />
       </div>
 
-      <div class="mt-3 space-y-2">
+      <div class="mt-3 space-y-2" tabindex={0} onPaste={(e) => handlePaste(e)}>
         <For each={children()}>
           {(child) => (
             <GroupChildEditor

--- a/src/sections/unified-item/components/UnifiedItemEditBody.tsx
+++ b/src/sections/unified-item/components/UnifiedItemEditBody.tsx
@@ -31,7 +31,6 @@ export type UnifiedItemEditBodyProps = {
   clipboardActions?: {
     onCopy: () => void
     onPaste: () => void
-    hasValidPastableOnClipboard: boolean
   }
   onAddNewItem?: () => void
   showAddItemButton?: boolean

--- a/src/sections/unified-item/components/UnifiedItemEditModal.tsx
+++ b/src/sections/unified-item/components/UnifiedItemEditModal.tsx
@@ -229,14 +229,13 @@ export const UnifiedItemEditModal = (_props: UnifiedItemEditModalProps) => {
   }
 
   // Clipboard functionality
-  const { handleCopy, handlePaste, hasValidPastableOnClipboard } =
-    useCopyPasteActions({
-      acceptedClipboardSchema: unifiedItemSchema,
-      getDataToCopy: () => item(),
-      onPaste: (data) => {
-        setItem(data)
-      },
-    })
+  const { handleCopy, handlePaste } = useCopyPasteActions({
+    acceptedClipboardSchema: unifiedItemSchema,
+    getDataToCopy: () => item(),
+    onPaste: (data) => {
+      setItem(data)
+    },
+  })
 
   return (
     <div class="flex flex-col h-full">
@@ -327,7 +326,6 @@ export const UnifiedItemEditModal = (_props: UnifiedItemEditModalProps) => {
             clipboardActions={{
               onCopy: handleCopy,
               onPaste: handlePaste,
-              hasValidPastableOnClipboard: hasValidPastableOnClipboard(),
             }}
             onAddNewItem={() => {
               openTemplateSearchModal({

--- a/src/sections/unified-item/components/UnifiedItemEditModal.tsx
+++ b/src/sections/unified-item/components/UnifiedItemEditModal.tsx
@@ -239,7 +239,7 @@ export const UnifiedItemEditModal = (_props: UnifiedItemEditModalProps) => {
 
   return (
     <div class="flex flex-col h-full">
-      <div class="flex-1 p-4">
+      <div class="flex-1 p-4" tabindex={0} onPaste={(e) => handlePaste(e)}>
         <Show
           when={
             isFoodItem(item()) || isRecipeItem(item()) || isGroupItem(item())

--- a/src/shared/modal/components/UnifiedModalContainer.tsx
+++ b/src/shared/modal/components/UnifiedModalContainer.tsx
@@ -19,7 +19,7 @@ function resolveStringValue<T extends string>(
   value: T | Accessor<T> | undefined,
 ): T | undefined {
   if (value === undefined) return undefined
-  return typeof value === 'function' ? (value as Accessor<T>)() : value
+  return typeof value === 'function' ? value() : value
 }
 
 /**
@@ -118,7 +118,7 @@ function ModalRenderer(props: ModalState) {
             }}
           >
             {props.type === 'confirmation'
-              ? resolveStringValue(props.cancelText) ?? 'Cancel'
+              ? (resolveStringValue(props.cancelText) ?? 'Cancel')
               : 'Cancel'}
           </button>
           <button
@@ -132,7 +132,7 @@ function ModalRenderer(props: ModalState) {
             }}
           >
             {props.type === 'confirmation'
-              ? resolveStringValue(props.confirmText) ?? 'Confirm'
+              ? (resolveStringValue(props.confirmText) ?? 'Confirm')
               : 'Confirm'}
           </button>
         </Modal.Footer>

--- a/src/shared/modal/helpers/modalHelpers.ts
+++ b/src/shared/modal/helpers/modalHelpers.ts
@@ -3,7 +3,7 @@
  * These provide convenient APIs for frequently used modal operations.
  */
 
-import type { Accessor, JSXElement } from 'solid-js'
+import type { Accessor } from 'solid-js'
 
 import { modalManager } from '~/shared/modal/core/modalManager'
 import type {
@@ -113,6 +113,7 @@ export function openEditModal(
     if (options.targetName !== undefined && options.targetName.length > 0) {
       if (typeof options.title === 'function') {
         fullTitle = () =>
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           `${(options.title as Accessor<ModalTitle>)()} - ${options.targetName}`
       } else {
         fullTitle = `${options.title} - ${options.targetName}`

--- a/src/shared/modal/tests/unifiedModal.test.ts
+++ b/src/shared/modal/tests/unifiedModal.test.ts
@@ -82,8 +82,8 @@ describe('Unified Modal System', () => {
   })
 
   it('should support Accessor types for reactive values', () => {
-    const [title, setTitle] = createSignal('Initial Title')
-    const [message, setMessage] = createSignal('Initial Message')
+    const [title] = createSignal('Initial Title')
+    const [message] = createSignal('Initial Message')
 
     const modalId = modalManager.openModal({
       type: 'confirmation',


### PR DESCRIPTION
## Summary

This PR fixes clipboard/paste UX by preferring the paste event's clipboardData when available and providing a small focused modal for programmatic paste flows. The change avoids triggering clipboard permission prompts and context menus (notably in Firefox) while keeping the existing confirmation flow as a fallback.

## Implementation details

- `useCopyPasteActions` (new `*.tsx`) was implemented to:
  - Read `event.clipboardData` when a paste DOM event is available and process it after user confirmation.
  - When no DOM event is available, open a small content modal that focuses a paste target and listens for a paste event (so the user can click "Paste" and press Ctrl/Cmd+V without triggering navigator.clipboard permission prompts).
  - Keep the fallback confirmation -> Clipboard API flow for programmatic paste.
- Added `onPaste={handlePaste}` and `tabindex={0}` to several editor containers so user-initiated paste (Ctrl/Cmd+V) is captured and processed via the event-based flow:
  - `UnifiedItemEditModal.tsx`
  - `GroupChildrenEditor.tsx`
  - `UnifiedRecipeEditView.tsx`
  - `RecipeEditView.tsx`
  - `MealEditView.tsx`
- Minor modal helper usage updates to show the focused paste area and allow a fallback "Paste from clipboard" action.

## Changed files

```


### Changed files (auto-appended)

src/sections/common/hooks/useClipboard.tsx
src/sections/common/hooks/useCopyPasteActions.ts
src/sections/common/hooks/useCopyPasteActions.tsx
src/sections/meal/components/MealEditView.tsx
src/sections/recipe/components/RecipeEditView.tsx
src/sections/recipe/components/UnifiedRecipeEditView.tsx
src/sections/unified-item/components/GroupChildrenEditor.tsx
src/sections/unified-item/components/UnifiedItemEditBody.tsx
src/sections/unified-item/components/UnifiedItemEditModal.tsx
src/shared/modal/components/UnifiedModalContainer.tsx
src/shared/modal/helpers/modalHelpers.ts
src/shared/modal/tests/unifiedModal.test.ts
src/shared/modal/types/modalTypes.ts


---
Generated by automated PR flow.
