### PR TITLE
Update dev script and item schema type

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.14.0",
   "packageManager": "pnpm@10.12.1",
   "scripts": {
-    "dev": "pnpm run gen-app-version && vinxi dev",
+    "dev": "pnpm run gen-app-version; vinxi dev",
     "build": "pnpm run gen-app-version && vinxi build",
     "gen-app-version": "bash ./.scripts/gen-app-version.sh",
     "type-check": "tsc --noEmit --skipLibCheck",

--- a/src/modules/diet/item/schema/itemSchema.ts
+++ b/src/modules/diet/item/schema/itemSchema.ts
@@ -17,7 +17,7 @@ export const itemSchema: z.ZodType<Item> = z.lazy(() =>
         id: z.number(),
         macros: macroNutrientsSchema,
       }),
-      __type: z.literal('Item'),
+      __type: z.literal('UnifiedItem'),
     }),
     // Recipe items don't have macros (inferred from children)
     z.object({
@@ -29,7 +29,7 @@ export const itemSchema: z.ZodType<Item> = z.lazy(() =>
         id: z.number(),
         children: z.array(itemSchema),
       }),
-      __type: z.literal('Item'),
+      __type: z.literal('UnifiedItem'),
     }),
     // Group items don't have macros (inferred from children)
     z.object({
@@ -40,7 +40,7 @@ export const itemSchema: z.ZodType<Item> = z.lazy(() =>
         type: z.literal('group'),
         children: z.array(itemSchema),
       }),
-      __type: z.literal('Item'),
+      __type: z.literal('UnifiedItem'),
     }),
   ]),
 )
@@ -49,7 +49,7 @@ type ItemBase = {
   id: number
   name: string
   quantity: number
-  __type: 'Item'
+  __type: 'UnifiedItem'
 }
 
 type FoodReference = { type: 'food'; id: number; macros: MacroNutrients }
@@ -93,7 +93,7 @@ function createBaseItem({
     id,
     name,
     quantity: Math.round(quantity * 100) / 100, // Round to 2 decimal places
-    __type: 'Item',
+    __type: 'UnifiedItem',
   }
 }
 

--- a/src/shared/utils/typeUtils.ts
+++ b/src/shared/utils/typeUtils.ts
@@ -13,7 +13,7 @@ export function isItem(obj: unknown): obj is Item {
     typeof obj === 'object' &&
     obj !== null &&
     '__type' in obj &&
-    obj.__type === 'Item'
+    obj.__type === 'UnifiedItem'
   )
 }
 


### PR DESCRIPTION
Refactor the development script to use semicolons for command separation and update the item schema to utilize the 'UnifiedItem' type for consistency.