### PR TITLE
Update error handling guidelines after removal of handleApiError utility

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -127,14 +127,15 @@ reportedBy: <agent-name.vXX>
 ## Naming & Structure
 - Use descriptive, action-based names. Avoid generic names. Organize by module.
 
+
 ## Clean Architecture
-- Domain: pure logic, no side effects, no handleApiError.
-- Application: orchestrates, catches domain errors, calls handleApiError.
+- Domain: pure logic, no side effects. Do not call observability or UI utilities from domain code.
+- Application: orchestrates, catches domain errors, maps them to user feedback and telemetry using `showError`, `showPromise`, and `logging`.
 
 ## Error Handling
-- Domain: only throws pure errors.
-- Application: always calls handleApiError with context.
-- Never log/throw errors in app code without handleApiError.
+- Domain: only throws pure errors. Do not import or call side-effect utilities from domain code.
+- Application: catch domain errors and use `showError` for user-facing messages and `logging` + `src/modules/observability` for telemetry; ensure context is attached to errors via `cause` or a `context` property.
+-- Never log/throw errors silently in app code; always record structured logs and surface friendly toasts when appropriate.
 
 ## Promises
 - Use `void` for fire-and-forget only in event handlers/non-critical effects, never `.catch(() => {})`.

--- a/docs/ARCHITECTURE_GUIDE.md
+++ b/docs/ARCHITECTURE_GUIDE.md
@@ -328,23 +328,23 @@ All code, comments, documentation, and commit messages must be written strictly 
 
 ## 🛑 Error Handling Standard
 
-All domain and application errors must be reported using the shared error handler utility:
+All domain and application errors should be handled with the repository's current observability and user-feedback utilities.
 
-- Use `handleApiError` from `~/shared/error/errorHandler` to log, report, or propagate errors.
-- Never throw or log errors directly in domain/application code without also calling `handleApiError`.
-- Always provide context (component, operation, additionalData) for traceability.
+- **Domain layer:** Throw pure errors and do not import side-effecting utilities (keep domain logic pure).
+- **Application layer:** Catch domain errors and map them to user-facing feedback and telemetry using `showError`, `showPromise`, and the `logging` / observability modules under `src/modules/observability`.
+- **UI/Controller:** May call `showError` for UI-specific error presentation.
 
-**Example:**
+Important: a previously used helper named `handleApiError` was removed from the codebase. Documentation and examples that reference `handleApiError` should be updated to use `showError` for toasts and `logging` / Sentry for telemetry.
+
+Recommended pattern:
+
 ```typescript
-import { handleApiError } from '~/shared/error/errorHandler'
-
-if (somethingWentWrong) {
-  handleApiError(new Error('Something went wrong'), {
-    component: 'itemGroupDomain',
-    operation: 'isRecipedGroupUpToDate',
-    additionalData: { groupId, groupRecipeId }
-  })
-  throw new Error('Something went wrong')
+try {
+  await domainFunc()
+} catch (e) {
+  logging.error('Operation failed', { error: e, component: 'MyComponent', operation: 'doThing' })
+  showError(e, { context: 'user-action' })
+  throw e
 }
 ```
 

--- a/docs/CODESTYLE_GUIDE.md
+++ b/docs/CODESTYLE_GUIDE.md
@@ -138,18 +138,18 @@ handleApiError(...)
 
 ### Application Layer (`~/modules/*/application/`)
 **Purpose**: Use cases, orchestration, data conversion, error handling
-- Responsible for catching errors from the domain and calling `handleApiError` with full context.
+- Responsible for catching errors from the domain and mapping them to user feedback and telemetry.
 - Handles all user feedback (toasts, logging, etc.).
+
+Use the centralized toast and logging utilities rather than a removed `handleApiError` helper. Recommended pattern:
 
 ```typescript
 try {
-  domainFunc()
+  await domainFunc()
 } catch (e) {
-  handleApiError(e, {
-    component: 'ItemGroupForm',
-    operation: 'submitGroup',
-    additionalData: { userId }
-  })
+  // Map error context to toast and telemetry
+  logging.error('ItemGroupForm.submitGroup failed', { error: e, component: 'ItemGroupForm', operation: 'submitGroup' })
+  showError(e, { context: 'user-action' })
   throw e
 }
 ```
@@ -176,24 +176,25 @@ try {
 
 ## 🛑 Error Handling Standard
 
-- **Domain layer:** Only throws pure errors. Never imports or uses `handleApiError` or any side-effect utility.
-- **Application layer:** Always catches errors from domain and calls `handleApiError` with context (`component`, `operation`, `additionalData`).
-- **UI/Controller:** May also call `handleApiError` for UI-specific errors.
+- **Domain layer:** Only throws pure errors. Do not import side-effect utilities or directly call observability services from domain code.
+- **Application layer:** Catch domain errors and map them to user-facing feedback and telemetry using existing utilities (`showError`, `showPromise`) and `logging` / observability modules.
+- **UI/Controller:** May call `showError` for UI-specific error presentation.
 
-**Example:**
+Notes:
+- The repository no longer uses a `handleApiError` helper. Documentation and code should use `showError(error, options)` for toasts and `logging` / `src/modules/observability` for telemetry and error reporting.
+- Prefer attaching context via `Error`'s `cause` or via a `context` property on the error object so handlers can read `err.cause?.code` or `err.context?.code`.
+
+**Example (recommended):**
 ```typescript
 // Domain
-throw new GroupConflictError('Group mismatch', { groupId, recipeId })
+throw new Error('Group mismatch: cannot mix different groups', { cause: { code: 'GROUP_CONFLICT', groupId, recipeId } })
 
 // Application
 try {
-  domainFunc()
+  await domainFunc()
 } catch (e) {
-  handleApiError(e, {
-    component: 'ItemGroupForm',
-    operation: 'submitGroup',
-    additionalData: { userId }
-  })
+  logging.error('submitGroup failed', { error: e, component: 'ItemGroupForm' })
+  showError(e, { context: 'user-action' })
   throw e
 }
 ```


### PR DESCRIPTION
Revise documentation to reflect the removal of the `handleApiError` utility. Update error handling practices to utilize `showError` for user feedback and `logging` for telemetry, ensuring that domain logic remains pure and free from side effects. Emphasize the importance of providing context for error reporting.