### PR TITLE
Move recipe loading check inside quantity update logic

### DIFF
--- a/.github/prompts/github-issue-new.prompt.md
+++ b/.github/prompts/github-issue-new.prompt.md
@@ -19,6 +19,7 @@ Core rules (short)
 - For bugs, include a `Related Files` section listing relevant paths discovered by searching the codebase.
 - Use `printf` with a heredoc to write the issue body to a temp file and call `gh issue create --body-file` (zsh-compatible; prefer double quotes).
 - Output only the final `gh` command in a fenced markdown code block.
+ - Never include "Additional context" sections or any agent-personal offers in the issue body. Do not append sentences like "If you want, I can open and inspect..." or other invitations to inspect code — the issue body must contain only the structured template content and investigation-derived facts.
 
 Workflow (refined)
 1) Clarify type
@@ -52,6 +53,7 @@ Workflow (refined)
      - verify with `cat /tmp/issue-body.md`
      - run `gh issue create --title "..." --label ... --body-file /tmp/issue-body.md`
    - Always check command output for errors and report them.
+   - Do NOT append any extra free-form suggestions, personal offers to inspect files, or an "Additional context" paragraph to the prepared issue body. The generated issue body must not contain solicitation lines (for example: "If you want, I can open and inspect ...").
 
 7) Output
    - After assembling everything, output only the final `gh` command inside a fenced markdown code block.

--- a/src/sections/item/components/ItemView/ItemEdit/ItemQuantityControls.tsx
+++ b/src/sections/item/components/ItemView/ItemEdit/ItemQuantityControls.tsx
@@ -37,23 +37,23 @@ export function ItemQuantityControls(props: ItemQuantityControlsProps) {
     const currentItem = untrack(props.itemDraft)
     const recipe = recipeResource.value()
 
-    if (
-      recipeResource.value.loading ||
-      recipe === null ||
-      recipe === undefined
-    ) {
-      logging.debug(
-        '[QuantityControls] Recipe resource loading or unavailable, skipping quantity update',
-      )
-      return
-    }
-
     logging.debug(
       '[QuantityControls] Update unified item quantity from field',
       { newQuantity },
     )
 
     if (isRecipeItem(currentItem)) {
+      if (
+        recipeResource.value.loading ||
+        recipe === null ||
+        recipe === undefined
+      ) {
+        logging.debug(
+          '[QuantityControls] Recipe resource loading or unavailable, skipping quantity update',
+        )
+        return
+      }
+
       props.setItemDraft(
         recipeItemUseCases.withEditedQuantity(currentItem, recipe, newQuantity),
       )


### PR DESCRIPTION
Ensure the recipe loading check occurs within the quantity update logic to prevent updates when the recipe is unavailable.

Fix #1380