### PR TITLE
Clarify output format and refactor recipe synchronization logic

### DIFF
--- a/.github/prompts/github-issue-new.prompt.md
+++ b/.github/prompts/github-issue-new.prompt.md
@@ -18,7 +18,7 @@ Core rules (short)
 - Use the matching template from `docs/` and produce Markdown output.
 - For bugs, include a `Related Files` section listing relevant paths discovered by searching the codebase.
 - Use `printf` with a heredoc to write the issue body to a temp file and call `gh issue create --body-file` (zsh-compatible; prefer double quotes).
-- Output only the final `gh` command in a fenced markdown code block.
+- Output only the final `gh` command in a fenced markdown code block delimited by four backticks.
  - Never include "Additional context" sections or any agent-personal offers in the issue body. Do not append sentences like "If you want, I can open and inspect..." or other invitations to inspect code — the issue body must contain only the structured template content and investigation-derived facts.
 
 Workflow (refined)
@@ -56,7 +56,7 @@ Workflow (refined)
    - Do NOT append any extra free-form suggestions, personal offers to inspect files, or an "Additional context" paragraph to the prepared issue body. The generated issue body must not contain solicitation lines (for example: "If you want, I can open and inspect ...").
 
 7) Output
-   - After assembling everything, output only the final `gh` command inside a fenced markdown code block.
+   - After assembling everything, output only the final `gh` command inside a fenced markdown code block delimited by four backticks.
 
 8) Session feedback
    - Confirm creation with the user and offer to edit content or labels.
@@ -73,5 +73,4 @@ Safety and shell notes
 - When creating files in `/tmp`, handle permissions and check write success.
 
 Output metadata
-- The final prompt output must be a single `gh` command in a fenced code block (no additional text).
-
+- The final prompt output must be a single `gh` command in a fenced markdown code block delimited by four backticks (no additional text).

--- a/src/modules/diet/item/application/recipeItemUseCases.ts
+++ b/src/modules/diet/item/application/recipeItemUseCases.ts
@@ -76,6 +76,6 @@ export const recipeItemUseCases = {
       return false
     }
 
-    return !RecipeItemExt.of(item).isInSyncWithRecipe(recipe.items)
+    return !RecipeItemExt.of(item).isInSyncWithRecipe(recipe)
   },
 }

--- a/src/modules/diet/item/application/recipeItemUseCases.ts
+++ b/src/modules/diet/item/application/recipeItemUseCases.ts
@@ -76,6 +76,6 @@ export const recipeItemUseCases = {
       return false
     }
 
-    return !ItemExt.of(item).isInSyncWithRecipe(recipe.items)
+    return !RecipeItemExt.of(item).isInSyncWithRecipe(recipe.items)
   },
 }

--- a/src/modules/diet/item/domain/ext/itemExt.ts
+++ b/src/modules/diet/item/domain/ext/itemExt.ts
@@ -1,6 +1,5 @@
 import { FoodItemExt } from '~/modules/diet/item/domain/ext/foodItemExt'
 import { GroupItemExt } from '~/modules/diet/item/domain/ext/groupItemExt'
-import { Items } from '~/modules/diet/item/domain/ext/itemsExt'
 import { RecipeItemExt } from '~/modules/diet/item/domain/ext/recipeItemExt'
 import {
   type FoodItem,
@@ -90,14 +89,6 @@ export const ItemExt = {
     return createMacroNutrients({ carbs: 0, fat: 0, protein: 0 })
   },
 
-  isInSyncWithRecipe(item: Item, recipeItems: readonly Item[]): boolean {
-    if (!isRecipeItem(item)) {
-      throw new Error('isInSyncWithRecipe can only be called on RecipeItem')
-    }
-
-    return Items.equals(recipeItems, item.reference.children)
-  },
-
   of(item: Item) {
     return {
       // Self reference
@@ -107,8 +98,7 @@ export const ItemExt = {
       reference: () => item.reference,
       // Derived props
       macros: () => MacroNutrientsExt.of(ItemExt.macros(item)),
-      isInSyncWithRecipe: (recipeItems: readonly Item[]) =>
-        ItemExt.isInSyncWithRecipe(item, recipeItems),
+
       // Type guards
       isFoodItem: () => isFoodItem(item),
       isRecipeItem: () => isRecipeItem(item),

--- a/src/modules/diet/item/domain/ext/itemsExt.ts
+++ b/src/modules/diet/item/domain/ext/itemsExt.ts
@@ -63,6 +63,20 @@ function equals(
   return true
 }
 
+// Normalize quantities so they sum to 1, preserving relative proportions
+function normalizedQuantitiesShallow(items: readonly Item[]): Item[] {
+  const totalQuantity = items.reduce((sum, item) => sum + item.quantity, 0)
+  if (totalQuantity === 0) {
+    return items.map((item) => ({ ...item, quantity: 1 / items.length }))
+  }
+
+  return items.map((item) => ({
+    ...item,
+    quantity: item.quantity / totalQuantity,
+  }))
+}
+
 export const Items = {
   equals,
+  normalizedQuantitiesShallow,
 }

--- a/src/modules/diet/item/domain/ext/recipeItemExt.ts
+++ b/src/modules/diet/item/domain/ext/recipeItemExt.ts
@@ -1,4 +1,5 @@
 import { ItemExt } from '~/modules/diet/item/domain/ext/itemExt'
+import { Items } from '~/modules/diet/item/domain/ext/itemsExt'
 import {
   type Item,
   type RecipeItem,
@@ -69,6 +70,10 @@ export const RecipeItemExt = {
     }
   },
 
+  isInSyncWithRecipe(item: RecipeItem, recipeItems: readonly Item[]): boolean {
+    return Items.equals(recipeItems, item.reference.children)
+  },
+
   of(item: RecipeItem) {
     const itemExt = ItemExt.of(item)
     return {
@@ -78,6 +83,8 @@ export const RecipeItemExt = {
         RecipeItemExt.syncWithOriginal(item, originalRecipeItems),
       scaleQuantityAndChildren: (newQuantity: number, recipe: Recipe) =>
         RecipeItemExt.scaleQuantityAndChildren(item, recipe, newQuantity),
+      isInSyncWithRecipe: (recipeItems: readonly Item[]) =>
+        RecipeItemExt.isInSyncWithRecipe(item, recipeItems),
     }
   },
 }

--- a/src/modules/diet/item/domain/ext/recipeItemExt.ts
+++ b/src/modules/diet/item/domain/ext/recipeItemExt.ts
@@ -42,22 +42,14 @@ export const RecipeItemExt = {
     const mainQuantity = Math.max(0.01, Math.round(newQuantity * 100) / 100)
     const totalChildQuantity = mainQuantity / recipe.prepared_multiplier
 
-    const currentChildQuantitySum = recipeItem.reference.children.reduce(
-      (sum, child) => sum + child.quantity,
-      0,
+    const normalizedChildren = Items.normalizedQuantitiesShallow(
+      recipeItem.reference.children,
     )
 
-    const childPercentages = recipeItem.reference.children.map((child) => ({
-      child,
-      percentage:
-        currentChildQuantitySum > 0
-          ? child.quantity / currentChildQuantitySum
-          : 1 / recipeItem.reference.children.length,
-    }))
-
-    const scaledChildren = childPercentages.map(({ child, percentage }) => ({
-      ...child,
-      quantity: Math.round(totalChildQuantity * percentage * 100) / 100,
+    const scaledChildren = normalizedChildren.map((normalizedChild) => ({
+      ...normalizedChild,
+      quantity:
+        Math.round(totalChildQuantity * normalizedChild.quantity * 100) / 100,
     }))
 
     return {
@@ -70,8 +62,16 @@ export const RecipeItemExt = {
     }
   },
 
-  isInSyncWithRecipe(item: RecipeItem, recipeItems: readonly Item[]): boolean {
-    return Items.equals(recipeItems, item.reference.children)
+  isInSyncWithRecipe(item: RecipeItem, recipe: Recipe): boolean {
+    const itemChildren = item.reference.children
+    const recipeChildren = recipe.items
+
+    const normalizedItemChildren =
+      Items.normalizedQuantitiesShallow(itemChildren)
+    const normalizedRecipeChildren =
+      Items.normalizedQuantitiesShallow(recipeChildren)
+
+    return Items.equals(normalizedItemChildren, normalizedRecipeChildren)
   },
 
   of(item: RecipeItem) {
@@ -83,8 +83,8 @@ export const RecipeItemExt = {
         RecipeItemExt.syncWithOriginal(item, originalRecipeItems),
       scaleQuantityAndChildren: (newQuantity: number, recipe: Recipe) =>
         RecipeItemExt.scaleQuantityAndChildren(item, recipe, newQuantity),
-      isInSyncWithRecipe: (recipeItems: readonly Item[]) =>
-        RecipeItemExt.isInSyncWithRecipe(item, recipeItems),
+      isInSyncWithRecipe: (recipe: Recipe) =>
+        RecipeItemExt.isInSyncWithRecipe(item, recipe),
     }
   },
 }

--- a/src/modules/diet/recipe/domain/recipeOperations.ts
+++ b/src/modules/diet/recipe/domain/recipeOperations.ts
@@ -101,6 +101,7 @@ export function getRecipePreparedQuantity(recipe: Recipe): number {
  * @param desiredPreparedQuantity - The desired prepared quantity in grams
  * @returns Object containing scaled items and the scaling factor used
  */
+// TODO: investigate duplicate function in recipeOperations.ts with RecipeItemExt.scaleQuantityAndChildren
 export function scaleRecipeByPreparedQuantity(
   recipe: Recipe,
   desiredPreparedQuantity: number,


### PR DESCRIPTION
Enhance the output format for the final GitHub command in issue bodies and refactor the synchronization logic for recipe items to use normalized quantities. Additionally, add a TODO to investigate a duplicate function in the recipe operations.

Fix #1382